### PR TITLE
Use setup tools if available and update versioning to pep 440 compatibility,

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 *.pyc
 *.pyo
 documentation/_build
+build
+dist
+*.egg-info
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -521,6 +521,7 @@ Version 3.0a     2015-xx-xx
 - update links to point to github
 - [Patch pyserial:34] Improvements to port_publisher.py example
 - [Feature pyserial:39] Support BlueTooth serial port discovery on Linux
+- Use setuptools if aviliable, fall back to distutils if unaviliable.
 
 Bugfixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -503,7 +503,7 @@ Bugfixes (cli):
 - [Bug pyserial:159] write() in serialcli.py not working with IronPython 2.7.4
 
 
-Version 3.x     2015-xx-xx
+Version 3.0a     2015-xx-xx
 --------------------------
 
 - Starting from this release, only 2.7 and 3.4 (or newer) are supported. The

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python
 
 # portable serial port access with python
 # this is a wrapper module for different platform implementations
@@ -6,7 +6,7 @@
 # (C) 2001-2010 Chris Liechti <cliechti@gmx.net>
 # this is distributed under a free software license, see license.txt
 
-VERSION = '3.x'
+VERSION = '3.0a'
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@
 # For Python 3.x use the corresponding Python executable,
 # e.g. "python3 setup.py ..."
 
-import sys
-
 try:
     from setuptools import setup
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,10 @@
 
 import sys
 
-from distutils.core import setup
-
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 # importing version does not work with Python 3 as files have not yet been
 # converted.


### PR DESCRIPTION
Use alpha status versioning for pip and tools to understand that this build is not translated to version 0.0

Use setup tools for develop mode support.