### PR TITLE
Always apply the calculated termios flags.

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -435,11 +435,10 @@ class Serial(SerialBase, PlatformSpecific):
             raise ValueError('Invalid vtime: %r' % vtime)
         cc[termios.VTIME] = vtime
         # activate settings
-        if [iflag, oflag, cflag, lflag, ispeed, ospeed, cc] != orig_attr:
-            termios.tcsetattr(
-                    self.fd,
-                    termios.TCSANOW,
-                    [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
+        termios.tcsetattr(
+            self.fd,
+            termios.TCSANOW,
+            [iflag, oflag, cflag, lflag, ispeed, ospeed, cc])
 
         # apply custom baud rate, if any
         if custom_baud is not None:


### PR DESCRIPTION
As reported on issue #30, on Linux the use of pyserial to read serial
input from various USB serial devices seems to put the port into a state
where the second time the application is executed the data stream becomes
corrupted and unreadable.

Investigating this showed that ANY non-default termios settings solved the
problem and this patch resolves it by ALWAYS calling tcsetattr to apply
the flags calculated.

This also seems to be relevant to issue #26.

Signed-off-by: Pat Thoyts <patthoyts@users.sourceforge.net>