### PR TITLE
fixed issue with 0 timeout on windows 10

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -275,7 +275,7 @@ class Serial(SerialBase):
                     read_ok = win32.ReadFile(self._port_handle, buf, n, ctypes.byref(rc), ctypes.byref(self._overlapped_read))
                     if not read_ok and win32.GetLastError() not in (win32.ERROR_SUCCESS, win32.ERROR_IO_PENDING):
                         raise SerialException("ReadFile failed (%r)" % ctypes.WinError())
-                    win32.WaitForSingleObject(self._overlapped_read.hEvent, win32.INFINITE)
+                    win32.GetOverlappedResult(self._port_handle, ctypes.byref(self._overlapped_read), ctypes.byref(rc), True)
                     read = buf.raw[:rc.value]
                 else:
                     read = bytes()


### PR DESCRIPTION
In the win32 documentation for ReadFile found at:

https://msdn.microsoft.com/en-gb/library/windows/desktop/aa365467(v=vs.85).aspx

it says:

"If hFile was opened with FILE_FLAG_OVERLAPPED, the following conditions
are in effect:

-  The lpOverlapped parameter must point to a valid and unique OVERLAPPED
structure, otherwise the function can incorrectly report that the read
operation is complete.

-  The lpNumberOfBytesRead parameter should be set to NULL. Use the
GetOverlappedResult function to get the actual number of bytes read. If
the hFile parameter is associated with an I/O completion port, you can
also get the number of bytes read by calling the
GetQueuedCompletionStatus function."

In the previous version of read the variable "rc" was set with ReadFile.
This works on windows 7 for all the hardware that I use but on windows
10 something has changed and rc is set to 0 by ReadFile if the serial
connection is to a "Beagle Bone Black". This means I am no longer able
to communicate with any of my Beagle Bone Blacks. I changed the read
method to use GetOverlappedResult and then it worked fine on windows 10
with all the hardware I plugged in.