### PR TITLE
Adds an override of BaseTransport.is_closing() to SerialTransport.

### DIFF
--- a/serial/aio.py
+++ b/serial/aio.py
@@ -36,6 +36,10 @@ class SerialTransport(asyncio.Transport):
     def __repr__(self):
         return '{self.__class__.__name__}({self._loop}, {self._protocol}, {self.serial})'.format(self=self)
 
+    def is_closing(self):
+        """Return True if the transport is closing or closed."""
+        return self._closing
+
     def close(self, exc=None):
         if self._closing:
             return


### PR DESCRIPTION
This is required for compatibility of SerialTransport with Python 3.5.1, when the `is_closing()` method was introduced.

There should be no impact on backwards compatibility.