### PR TITLE
PEP 396 compatible __version__ attribute.

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -13,7 +13,9 @@ import sys
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-VERSION = '3.1a0'
+__version__ = '3.1a0'
+
+VERSION = __version__
 
 # pylint: disable=wrong-import-position
 if sys.platform == 'cli':


### PR DESCRIPTION
PEP396: Module Version Numbers tells us that module version numbers should be available in a `__version__` attribute.  Historically, pySerial has used VERSION instead. This commit adds `__version__` and aliases the legacy VERSION to it for backwards compatibility.

Note that although PEP396 is not yet accepted, this is a very widely followed standard and I was surprised that pySerial did not follow it.