### PR TITLE
Call the superclass initializer in SerialTransport.

### DIFF
--- a/serial/aio.py
+++ b/serial/aio.py
@@ -21,6 +21,7 @@ import logging
 
 class SerialTransport(asyncio.Transport):
     def __init__(self, loop, protocol, serial_instance):
+        super().__init__()
         self._loop = loop
         self._protocol = protocol
         self.serial = serial_instance


### PR DESCRIPTION
SerialTransport ultimately inherits from asyncio.transports.BaseTransport. The existing code did not call the superclass initializer, so subsequent calls to inherited methods such as SerialTransport.get_extra_info() would fail.