### PR TITLE
test: open serial on PTY

### DIFF
--- a/test/test_pty.py
+++ b/test/test_pty.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#
+# This file is part of pySerial - Cross platform serial port support for Python
+# (C) 2015 Chris Liechti <cliechti@gmx.net>
+#
+# SPDX-License-Identifier:    BSD-3-Clause
+"""
+Test PTY related functionality.
+"""
+
+import os
+import sys
+import pty
+import unittest
+import serial
+
+
+class Test_Pty_Serial_Open(unittest.TestCase):
+    """Test PTY serial open"""
+
+    def setUp(self):
+        # Open PTY
+        self.master, self.slave = pty.openpty()
+
+    def test_pty_serial_open(self):
+        """Open serial port on slave"""
+        ser = serial.Serial(os.ttyname(self.slave))
+        ser.close()
+
+
+if __name__ == '__main__':
+    sys.stdout.write(__doc__)
+    # When this module is executed from the command-line, it runs all its tests
+    unittest.main()


### PR DESCRIPTION
Perhaps it would be convenient to add a test to avoid #59 or #76 in the future.