### PR TITLE
Only install serial.aio on Python >= 3.4.

### DIFF
--- a/serial/aio/__init__.py
+++ b/serial/aio/__init__.py
@@ -426,3 +426,4 @@ if __name__ == '__main__':
     loop.run_until_complete(coro)
     loop.run_forever()
     loop.close()
+

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@
 # (C) 2001-2016 Chris Liechti <cliechti@gmx.net>
 #
 # SPDX-License-Identifier:    BSD-3-Clause
+import sys
 
 try:
     from setuptools import setup
@@ -18,6 +19,16 @@ except ImportError:
 import serial
 version = serial.VERSION
 
+packages = [
+    'serial',
+    'serial.tools',
+    'serial.urlhandler',
+    'serial.threaded',
+]
+
+if sys.version_info >= (3, 4):
+    packages += ['serial.aio']
+
 setup(
     name="pyserial",
     description="Python Serial Port Extension",
@@ -25,7 +36,7 @@ setup(
     author="Chris Liechti",
     author_email="cliechti@gmx.net",
     url="https://github.com/pyserial/pyserial",
-    packages=['serial', 'serial.tools', 'serial.urlhandler', 'serial.threaded'],
+    packages=packages,
     license="BSD",
     long_description="""\
 Python Serial Port Extension for Win32, OSX, Linux, BSD, Jython, IronPython


### PR DESCRIPTION
Changes module `serial/aio.py` into a package `serial/aio/__init__.py`.
This allows us to use `distutils` or `setuptools` to optionally install this package.  The changes to `setup.py` detect whether the current Python version is >= 3.4 and if so append `'serial.aio'` to the list of packages to be installed.

Be aware that when testing this you *must* have previously cleaned any existing distutils/setuptools build directory with:

    python setup.py clean --all

 otherwise the old aio may continue to be installed. This will only be an issue for pyserial developers.