### PR TITLE
serial cannot be a namespace package as it exports names

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -7,6 +7,7 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+import sys
 import importlib
 
 from serial.serialutil import *

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -8,9 +8,6 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 
 import importlib
-import sys
-from pkgutil import extend_path
-
 
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
@@ -18,9 +15,6 @@ from serial.serialutil import *
 __version__ = '3.1.1'
 
 VERSION = __version__
-
-# serial is a namespace package
-__path__ = extend_path(__path__, __name__)
 
 # pylint: disable=wrong-import-position
 if sys.platform == 'cli':


### PR DESCRIPTION
It turns out that we can't use namespace packages with pySerial, because the serial package exports names such as `serial_for_url`, and name exports from `__init__.py` are incompatible with the namespace package mechanism.

This was the reason for the failure in the new `pyserial-asyncio` package.

This is the companion pull request to PR2 in `pyserial-asyncio` which also converts that to a regular package called `serial_asyncio` which must exist side-by-side with `serial`.