### PR TITLE
linux: list_ports use interface path for multi location

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -28,17 +28,28 @@ class SysFS(list_ports_common.ListPortInfo):
             self.subsystem = None
         # check device type
         if self.subsystem == 'usb-serial':
-            self.usb_device_path = os.path.dirname(os.path.dirname(self.device_path))
+            self.usb_interface_path = os.path.dirname(self.device_path)
         elif self.subsystem == 'usb':
-            self.usb_device_path = os.path.dirname(self.device_path)
+            self.usb_interface_path = self.device_path
         else:
-            self.usb_device_path = None
+            self.usb_interface_path = None
         # fill-in info for USB devices
-        if self.usb_device_path is not None:
+        if self.usb_interface_path is not None:
+            self.usb_device_path = os.path.dirname(self.usb_interface_path)
+
+            try:
+                num_if = int(self.read_line(self.usb_device_path, 'bNumInterfaces'))
+            except ValueError:
+                num_if = 1
+
             self.vid = int(self.read_line(self.usb_device_path, 'idVendor'), 16)
             self.pid = int(self.read_line(self.usb_device_path, 'idProduct'), 16)
             self.serial_number = self.read_line(self.usb_device_path, 'serial')
-            self.location = os.path.basename(self.usb_device_path)
+            if num_if > 1:  # multi interface devices like FT4232
+                self.location = os.path.basename(self.usb_interface_path)
+            else:
+                self.location = os.path.basename(self.usb_device_path)
+
             self.manufacturer = self.read_line(self.usb_device_path, 'manufacturer')
             self.product = self.read_line(self.usb_device_path, 'product')
             self.interface = self.read_line(self.device_path, 'interface')


### PR DESCRIPTION
On devices with multiple serial interfaces, like FT4232,
the usb_device path is the same for all interfaces, so hwid does
not uniquely identify the interface.
So in this case use the basename of the interface directory.

Single interface:
hwid: USB VID:PID=0403:6015 SER=DN00RHW0 LOCATION=3-1.1
Multiple interface:
hwid: USB VID:PID=0403:6011 SER=FT97WK0I LOCATION=3-1.2:1.1

Signed-off-by: Eliot Blennerhassett eliot@blennerhassett.gen.nz
