### PR TITLE
fix encoding error on windows

### DIFF
--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -20,6 +20,7 @@ from ctypes.wintypes import ULONG
 from ctypes.wintypes import LPCSTR
 from ctypes.wintypes import HKEY
 from ctypes.wintypes import BYTE
+import locale
 import serial
 from serial.win32 import ULONG_PTR
 from serial.tools import list_ports_common
@@ -54,7 +55,7 @@ def string(buffer):
         if c == 0:
             break
         s.append(chr(c & 0xff))  # "& 0xff": hack to convert signed to unsigned
-    return ''.join(s)
+    return ''.join(s).encode('latin-1').decode(locale.getpreferredencoding(False))
 
 
 class GUID(ctypes.Structure):


### PR DESCRIPTION
Some attributes may have non-english characters (like ```info.description```) and are not utf-8 encoded.
```locale.getpreferredencoding``` will return ANSI code page (on my system, it is ```cp936```) so we can re-decode the strings with it.