### PR TITLE
Fix "TypeError: an integer is required" error from data_received.

### DIFF
--- a/serial/threaded/__init__.py
+++ b/serial/threaded/__init__.py
@@ -105,7 +105,7 @@ class FramedPacket(Protocol):
                 self.handle_packet(self.packet)
                 del self.packet[:]
             elif self.in_packet:
-                self.packet.append(byte)
+                self.packet.extend(byte)
             else:
                 self.handle_out_of_packet_data(byte)
 


### PR DESCRIPTION
Change append to extend in serial.threading.FramedPacket data_receive function, wich will work both under Python 2.7, and Python 3.5, without throwing and error.