### PR TITLE
Fix python3 bytes issues when running rfc2217_server.py

### DIFF
--- a/examples/rfc2217_server.py
+++ b/examples/rfc2217_server.py
@@ -56,7 +56,7 @@ class Redirector(object):
                 data = self.serial.read(self.serial.in_waiting or 1)
                 if data:
                     # escape outgoing data when needed (Telnet IAC (0xff) character)
-                    self.write(serial.to_bytes(self.rfc2217.escape(data)))
+                    self.write(b''.join(self.rfc2217.escape(data)))
             except socket.error as msg:
                 self.log.error('{}'.format(msg))
                 # probably got disconnected
@@ -76,7 +76,7 @@ class Redirector(object):
                 data = self.socket.recv(1024)
                 if not data:
                     break
-                self.serial.write(serial.to_bytes(self.rfc2217.filter(data)))
+                self.serial.write(b''.join(self.rfc2217.filter(data)))
             except socket.error as msg:
                 self.log.error('{}'.format(msg))
                 # probably got disconnected

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -850,12 +850,12 @@ class Serial(SerialBase):
 
     def telnet_send_option(self, action, option):
         """Send DO, DONT, WILL, WONT."""
-        self._internal_raw_write(to_bytes([IAC, action, option]))
+        self._internal_raw_write(IAC + action + option)
 
     def rfc2217_send_subnegotiation(self, option, value=b''):
         """Subnegotiation of RFC2217 parameters."""
         value = value.replace(IAC, IAC_DOUBLED)
-        self._internal_raw_write(to_bytes([IAC, SB, COM_PORT_OPTION, option] + list(value) + [IAC, SE]))
+        self._internal_raw_write(IAC + SB + COM_PORT_OPTION + option + value + IAC + SE)
 
     def rfc2217_send_purge(self, value):
         """\
@@ -989,12 +989,12 @@ class PortManager(object):
 
     def telnet_send_option(self, action, option):
         """Send DO, DONT, WILL, WONT."""
-        self.connection.write(to_bytes([IAC, action, option]))
+        self.connection.write(IAC + action + option)
 
     def rfc2217_send_subnegotiation(self, option, value=b''):
         """Subnegotiation of RFC 2217 parameters."""
         value = value.replace(IAC, IAC_DOUBLED)
-        self.connection.write(to_bytes([IAC, SB, COM_PORT_OPTION, option] + list(value) + [IAC, SE]))
+        self.connection.write(IAC + SB + COM_PORT_OPTION + option + value + IAC + SE)
 
     # - check modem lines, needs to be called periodically from user to
     # establish polling


### PR DESCRIPTION
This changeset fixes issues when passing `to_bytes()` a sequence/generator of bytes, which causes `bytearray` to raise a `TypeError` on python3. Fixes #180.