### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,8 +118,8 @@ Bugfixes (win32):
 - don't recreate overlapped structures and events on each
   read/write.
 - don't set unneeded event masks.
-- dont use DOS device names for ports > 9.
-- remove send timeout (its not used in the linux impl. anyway).
+- don't use DOS device names for ports > 9.
+- remove send timeout (it's not used in the linux impl. anyway).
 
 
 Version 1.21    30 Sep 2003
@@ -199,7 +199,7 @@ Bugfixes (posix):
 
 - ``fd == 0`` fix from Vsevolod Lobko
 - netbsd fixes from Erik Lindgren
-- Dynamicaly lookup baudrates and some cleanups
+- Dynamically lookup baudrates and some cleanups
 
 Bugfixes (examples):
 
@@ -234,7 +234,7 @@ Bugfixes (win32):
 New Features:
 
 - ``dsrdtr`` setting to enable/disable DSR/DTR flow control independently
-  from the ``rtscts`` setting. (Currenly Win32 only, ignored on other
+  from the ``rtscts`` setting. (Currently Win32 only, ignored on other
   platforms)
 
 
@@ -379,7 +379,7 @@ New Features:
   affects Win32 as on other platforms, that setting was ignored anyway.
 - Improved xreadlines, it is now a generator function that yields lines as they
   are received (previously it called readlines which would only return all
-  lines read after a read-timeout). However xreadlines is deprecated an not
+  lines read after a read-timeout). However xreadlines is deprecated and not
   available when the io module is used. Use ``for line in Serial(...):``
   instead.
 
@@ -405,13 +405,13 @@ New Features:
 - Moved some of the examples to serial.tools so that they can be used
   with ``python -m``
 - serial port enumeration now included as ``serial.tools.list_ports``
-- URL handers for ``serial_for_url`` are now imported dynamically. This allows
+- URL handlers for ``serial_for_url`` are now imported dynamically. This allows
   to add protocols w/o editing files. The list
   ``serial.protocol_handler_packages`` can be used to add or remove user
   packages with protocol handlers (see docs for details).
 - new URL type: hwgrep://<regexp> uses list_ports module to search for ports
   by their description
-- serveral internal changes to improve Python 3.x compatibility (setup.py,
+- several internal changes to improve Python 3.x compatibility (setup.py,
   use of absolute imports and more)
 
 Bugfixes:

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Documentation
 =============
 For API documentation, usage and examples see files in the "documentation"
 directory.  The ".rst" files can be read in any text editor or being converted to
-HTML or PDF using Sphinx_. A HTML version is online at
+HTML or PDF using Sphinx_. An HTML version is online at
 https://pythonhosted.org/pyserial/
 
 Examples

--- a/documentation/examples.rst
+++ b/documentation/examples.rst
@@ -82,7 +82,7 @@ portable (runs on POSIX, Windows, etc).
   using :rfc:`2217` requests. The status lines (DSR/CTS/RI/CD) are polled every
   second and notifications are sent to the client.
 - Telnet character IAC (0xff) needs to be doubled in data stream. IAC followed
-  by an other value is interpreted as Telnet command sequence.
+  by another value is interpreted as Telnet command sequence.
 - Telnet negotiation commands are sent when connecting to the server.
 - RTS/DTR are activated on client connect and deactivated on disconnect.
 - Default port settings are set again when client disconnects.
@@ -187,7 +187,7 @@ Installation as daemon:
 - Copy the script ``port_publisher.py`` to ``/usr/local/bin``.
 - Copy the script ``port_publisher.sh`` to ``/etc/init.d``.
 - Add links to the runlevels using ``update-rc.d port_publisher.sh defaults 99``
-- Thats it :-) the service will be started on next reboot. Alternatively run
+- That's it :-) the service will be started on next reboot. Alternatively run
   ``invoke-rc.d port_publisher.sh start`` as root.
 
 .. versionadded:: 2.5 new example

--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -577,7 +577,7 @@ Native ports
         :platform: Posix
         :platform: Windows
 
-        Cancel a pending read operation from an other thread. A blocking
+        Cancel a pending read operation from another thread. A blocking
         :meth:`read` call is aborted immediately. :meth:`read` will not report
         any error but return all data received up to that point (similar to a
         timeout).
@@ -591,7 +591,7 @@ Native ports
         :platform: Posix
         :platform: Windows
 
-        Cancel a pending write operation from an other thread. The
+        Cancel a pending write operation from another thread. The
         :meth:`write` method will return immediately (no error indicated).
         However the OS may still be sending from the buffer, a separate call to
         :meth:`reset_output_buffer` may be needed.
@@ -1258,7 +1258,7 @@ asyncio
 ``asyncio`` was introduced with Python 3.4. Experimental support for pySerial
 is provided via a separate distribution `pyserial-asyncio`_.
 
-It is currently under developement, see:
+It is currently under development, see:
 
 - http://pyserial-asyncio.readthedocs.io/
 - https://github.com/pyserial/pyserial-asyncio

--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -97,7 +97,7 @@ serial.tools.list_ports``). It also contains the following functions.
 
     .. attribute:: interface
 
-        Interface specifc description, e.g. used in compound USB devices.
+        Interface specific description, e.g. used in compound USB devices.
 
     Comparison operators are implemented such that the :obj:`ListPortInfo` objects
     can be sorted by ``device``. Strings are split into groups of numbers and

--- a/documentation/url_handlers.rst
+++ b/documentation/url_handlers.rst
@@ -197,7 +197,7 @@ Outputs::
     000002.284 RX   00F0  F0 F1 F2 F3 F4 F5 F6 F7  F8 F9 FA FB FC FD FE FF  ................
     000002.284 BRK  send_break 0.25
 
-An other example, on POSIX, open a second terminal window and find out it's
+Another example, on POSIX, open a second terminal window and find out it's
 device (e.g. with the ``ps`` command in the TTY column), assumed to be
 ``/dev/pts/2`` here, double quotes are used so that the ampersand in the URL is
 not interpreted by the shell::


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).