### PR TITLE
Exclusive access on POSIX.

### DIFF
--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -12,7 +12,7 @@ Native ports
 
 .. class:: Serial
 
-    .. method:: __init__(port=None, baudrate=9600, bytesize=EIGHTBITS, parity=PARITY_NONE, stopbits=STOPBITS_ONE, timeout=None, xonxoff=False, rtscts=False, write_timeout=None, dsrdtr=False, inter_byte_timeout=None)
+    .. method:: __init__(port=None, baudrate=9600, bytesize=EIGHTBITS, parity=PARITY_NONE, stopbits=STOPBITS_ONE, timeout=None, xonxoff=False, rtscts=False, write_timeout=None, dsrdtr=False, inter_byte_timeout=None, exclusive=None)
 
         :param port:
             Device name or :const:`None`.
@@ -52,6 +52,9 @@ Native ports
 
         :param float inter_byte_timeout:
             Inter-character timeout, :const:`None` to disable (default).
+            
+        :param bool exclusive:
+            Set exclusive access mode (POSIX only).
 
         :exception ValueError:
             Will be raised when parameter are out of range, e.g. baud rate, data bits.

--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -54,7 +54,8 @@ Native ports
             Inter-character timeout, :const:`None` to disable (default).
             
         :param bool exclusive:
-            Set exclusive access mode (POSIX only).
+            Set exclusive access mode (POSIX only).  A port cannot be opened in 
+            exclusive access mode if it is already open in exclusive access mode.
 
         :exception ValueError:
             Will be raised when parameter are out of range, e.g. baud rate, data bits.

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -13,7 +13,7 @@ import importlib
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-__version__ = '3.2.1'
+__version__ = '3.2.1.dev-rg1'
 
 VERSION = __version__
 

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -13,7 +13,7 @@ import importlib
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-__version__ = '3.2.1.dev-rg1'
+__version__ = '3.2.1+rg.1'
 
 VERSION = __version__
 

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -13,7 +13,7 @@ import importlib
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-__version__ = '3.2.1+rg.1'
+__version__ = '3.2.1'
 
 VERSION = __version__
 

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -302,6 +302,17 @@ class Serial(SerialBase, PlatformSpecific):
         """Set communication parameters on opened port."""
         if self.fd is None:
             raise SerialException("Can only operate on a valid file descriptor")
+            
+        # if exclusive lock is requested, create it before we modify anything else
+        if self._exclusive is not None:
+            if self._exclusive:
+                try:
+                    fcntl.flock(self.fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except IOError as msg:
+                    raise SerialException(msg.errno, "Could not exclusively lock port {}: {}".format(self._port, msg))
+            else:
+                fcntl.flock(self.fd, fcntl.LOCK_UN)
+            
         custom_baud = None
 
         vmin = vtime = 0                # timeout is done via select

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -185,6 +185,7 @@ class SerialBase(io.RawIOBase):
                  write_timeout=None,
                  dsrdtr=False,
                  inter_byte_timeout=None,
+                 exclusive=None,
                  **kwargs):
         """\
         Initialize comm port object. If a "port" is given, then the port will be
@@ -211,6 +212,7 @@ class SerialBase(io.RawIOBase):
         self._rts_state = True
         self._dtr_state = True
         self._break_state = False
+        self._exclusive = None
 
         # assign values using get/set methods using the properties feature
         self.port = port
@@ -224,6 +226,8 @@ class SerialBase(io.RawIOBase):
         self.rtscts = rtscts
         self.dsrdtr = dsrdtr
         self.inter_byte_timeout = inter_byte_timeout
+        self.exclusive = exclusive
+        
         # watch for backward compatible kwargs
         if 'writeTimeout' in kwargs:
             self.write_timeout = kwargs.pop('writeTimeout')
@@ -301,6 +305,18 @@ class SerialBase(io.RawIOBase):
         if bytesize not in self.BYTESIZES:
             raise ValueError("Not a valid byte size: {!r}".format(bytesize))
         self._bytesize = bytesize
+        if self.is_open:
+            self._reconfigure_port()
+
+    @property
+    def exclusive(self):
+        """Get the current exclusive access setting."""
+        return self._exclusive
+    
+    @exclusive.setter
+    def exclusive(self, exclusive):
+        """Change the exclusive access setting."""
+        self._exclusive = exclusive
         if self.is_open:
             self._reconfigure_port()
 


### PR DESCRIPTION
On Linux machines, opening a serial port is non-exclusive; you can open multiple simultaneous connections to the same serial port.  This does not seem to be the case on Windows, but more the point is almost certainly not the behavior you want, various processes all stepping on one another's comm.

Unfortunately you can't just open the Serial object then fcntl.flock it because, in between, initializing the Serial port did all manner of things to settings like baud rate, timeouts, etc.  So the fix is that the call to flock has to happen immediately, right after the os.open of the raw port, before any of the termios action.

This pull adds an exclusive keyword argument to Serial.__init__ and corresponding data descriptors.  On a serialposix.Serial, setting exclusive explicitly True or False manipulates the lock for this process, meaning that if you make two attempts to open a Serial(port, exclusive=True), the second will fail.  On serialwin32 and serialjava, the exclusive flag is supported but ignored.  Windows already does the right thing, and I don't have access to a Jython installation to check the Java behavior.

This change is kind of essential for applications that try to do autodetection of "Alright, which serial port has my Widgetek brand Widget."