### PR TITLE
Advantech multi-port controllers on Linux

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -73,6 +73,7 @@ def comports():
     devices.extend(glob.glob('/dev/ttyACM*'))   # usb-serial with CDC-ACM profile
     devices.extend(glob.glob('/dev/ttyAMA*'))   # ARM internal port (raspi)
     devices.extend(glob.glob('/dev/rfcomm*'))   # BT serial devices
+    devices.extend(glob.glob('/dev/ttyAP*'))    # Advantech multi-port serial controllers
     return [info
             for info in [SysFS(d) for d in devices]
             if info.subsystem != "platform"]    # hide non-present internal serial ports


### PR DESCRIPTION
Advantech makes multi-port PCI/PCIe to serial controllers used in industrial sorts of applications.  Their driver names the ports /dev/ttyAP*.  This pull adds that pattern to the list in serial.tools.list_ports_linux.comports()