### PR TITLE
Implement StructuredPacket and write basic unit test.

### DIFF
--- a/serial/threaded/__init__.py
+++ b/serial/threaded/__init__.py
@@ -118,6 +118,62 @@ class FramedPacket(Protocol):
         pass
 
 
+class StructuredPacket(Protocol):
+    """
+    Read binary packets. Packets are expected to be fixed length have a header
+    to mark its beginning.
+    """
+
+    HEADER = b'\x01\x02\x03\x04\x05'
+
+    def __init__(self, data_size):
+        """Initialize with packet size excluding header"""
+        try:
+            self.data_size = int(data_size)
+        except ValueError as exc:
+            raise ValueError("Exepected arg 'size' to be int: " + str(exc))
+        self.packet = bytearray()
+        self.in_data = False
+        self.header_pos = 0
+        self.transport = None
+
+    def connection_made(self, transport):
+        """Store transport"""
+        self.transport = transport
+
+    def conneciton_lost(self, exc):
+        """Forget transport"""
+        self.transport = None
+        del self.packet[:]
+        super(StructuredPacket, self).connection_lost(exc)
+
+    def data_received(self, data):
+        """Find data after HEADER, call handle_packet"""
+        for byte in serial.iterbytes(data):
+            if self.in_data and (len(self.packet) < self.data_size):
+                self.packet.extend(byte)
+                if len(self.packet) == self.data_size:
+                    self.in_data = False
+                    # make read-only copy
+                    self.handle_packet(bytes(self.packet))
+                    del self.packet[:]
+            # Since there is no 'byte' object, indexing a bytes or bytearray
+            # object yields an int. Instead, we need to compare a bytes object
+            # of size 1 with a bytes object of size 1
+            elif byte == self.HEADER[self.header_pos:self.header_pos+1]:
+                self.header_pos += 1
+                if self.header_pos == len(self.HEADER):
+                    self.header_pos = 0
+                    self.in_data = True
+            else:
+                self.header_pos = 0
+
+    def handle_packet(self, packet):
+        """Process packets - to be overridden by subclassing"""
+        raise serial.threaded.NotImplementedError(
+                'please implement functionality in handle_packet')
+
+
 class LineReader(Packetizer):
     """
     Read and write (Unicode) lines from/to serial port.


### PR DESCRIPTION
Currently none of the packet objects in `serial.threaded` guarantee packet alignment. The closest is FramedPacket which is good for strictly unicode packets but not for packets with arbitrary binary data because it expects a sequence that starts with a '(' (0x28) and ends with a ')' (0x29). This means the bytes 0x28 and 0x29 cannot appear anywhere in the data.

```c
struct Packet {
	int sensor1;
	int sensor2;
}
```
If we send this over the wire and start reading at an arbitrary time, it's impossible to know what byte of the packet we're reading. To mitigate this we can add a header and some padding.

```c
struct Packet {
	char header[5]; // Any sequence without a '\0'
	int sensor1;
	char pad1;      // '\0'
	int sensor2;
	char pad2;      // '\0'
}
```
Now we just need to wait until the header sequence is read and we can consume the rest of the packet without worrying about alignment.