### PR TITLE
Handle EAGAIN on write (BlockingIOError: [Errno 11] Resource temporar…

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -560,6 +560,9 @@ class Serial(SerialBase, PlatformSpecific):
                 tx_len -= n
             except SerialException:
                 raise
+            except BlockingIOError:
+                # EAGAIN is common when in non blocking mode
+                pass
             except OSError as v:
                 if v.errno != errno.EAGAIN:
                     raise SerialException('write failed: {}'.format(v))


### PR DESCRIPTION
…ily unavailable)

As the pyserial-asyncio uses non blocking mode posix serial needs to handle the EAGAIN error which is a non fatal error that is often seen in non blocking mode.

Without it we get this error in asyncio mode when writing a lot of data..

```
protocol: <__main__.SerialConnection object at 0xb6d0bd8c>
transport: SerialTransport(<_UnixSelectorEventLoop running=True closed=False debug=False>, <__main__.SerialConnection object at 0xb6d0bd8c>, Serial<id=0xb6d0b9ac, open=True>(port='/dev/ttyACM0', baudrate=115200, bytesize=8, parity='N', stopbits=1, timeout=0, xonxoff=False, rtscts=False, dsrdtr=False))
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/dist-packages/pyserial-3.3-py3.4.egg/serial/serialposix.py", line 534, in write
    n = os.write(self.fd, d)
BlockingIOError: [Errno 11] Resource temporarily unavailable
```

Fixes this issue https://github.com/pyserial/pyserial-asyncio/issues/20