### PR TITLE
Added query also for &MI_xx parameter from HardwareID string

### DIFF
--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -39,6 +39,7 @@ class ListPortInfo(object):
         # USB specific data
         self.vid = None
         self.pid = None
+        self.mi = None
         self.serial_number = None
         self.location = None
         self.manufacturer = None

--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -210,13 +210,15 @@ def iterate_comports():
             # in case of USB, make a more readable string, similar to that form
             # that we also generate on other platforms
             if szHardwareID_str.startswith('USB'):
-                m = re.search(r'VID_([0-9a-f]{4})(&PID_([0-9a-f]{4}))?(\\(\w+))?', szHardwareID_str, re.I)
+                m = re.search(r'VID_([0-9a-f]{4})(&PID_([0-9a-f]{4}))?(&MI_(\d{2}))?(\\(\w+))?', szHardwareID_str, re.I)
                 if m:
                     info.vid = int(m.group(1), 16)
                     if m.group(3):
                         info.pid = int(m.group(3), 16)
                     if m.group(5):
-                        info.serial_number = m.group(5)
+                        info.mi = int(m.group(5))
+                    if m.group(7):
+                        info.serial_number = m.group(7)
                 # calculate a location string
                 loc_path_str = ctypes.create_unicode_buffer(250)
                 if SetupDiGetDeviceRegistryProperty(


### PR DESCRIPTION
Some USB Composite Devices will have a MI ('multiple interfaces')
parameter which indicates what is the interface number of that USB
device.
If this &MI_xx parameter is present the current regexp will not work correctly and it will not get the 'serial_number'. This will fix also that issue.