### PR TITLE
Don't reset input buffer on open

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -292,7 +292,6 @@ class Serial(SerialBase, PlatformSpecific):
                 pass
             else:
                 raise
-        self.reset_input_buffer()
         self.pipe_abort_read_r, self.pipe_abort_read_w = os.pipe()
         self.pipe_abort_write_r, self.pipe_abort_write_w = os.pipe()
         fcntl.fcntl(self.pipe_abort_read_r, fcntl.F_SETFL, os.O_NONBLOCK)


### PR DESCRIPTION
Fixes #249 which causes data that has been buffering in the OS to be dropped on Posix systems with no way to recover.  Windows does not reset_input_buffer on open.