### PR TITLE
list_ports: set default `name` attribute

### DIFF
--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -10,6 +10,7 @@
 import re
 import glob
 import os
+import os.path
 
 
 def numsplit(text):
@@ -33,7 +34,7 @@ class ListPortInfo(object):
 
     def __init__(self, device=None):
         self.device = device
-        self.name = None
+        self.name = os.path.basename(device)
         self.description = 'n/a'
         self.hwid = 'n/a'
         # USB specific data

--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -24,7 +24,6 @@ class SysFS(list_ports_common.ListPortInfo):
             is_link = True
         else:
             is_link = False
-        self.name = os.path.basename(device)
         self.usb_device_path = None
         if os.path.exists('/sys/class/tty/{}/device'.format(self.name)):
             self.device_path = os.path.realpath('/sys/class/tty/{}/device'.format(self.name))


### PR DESCRIPTION
See #262

Set the default `ListPortInfo.name` attribute from the full `device` name,
using `os.path.basename(device)`

This should be valid for all platforms, but can be easily overridden in
platform specific code that populates the `ListPortInfo` object.