### PR TITLE
Add support to serial_for_url for handlers with fully qualified package names.

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -38,6 +38,28 @@ protocol_handler_packages = [
 ]
 
 
+def _find_module_for_protocol(protocol, packages):
+    """Return the module that contains the handler for the specified protocol.
+    
+    If the protocol appears to be a fully qualified Python module (i.e. a.b.c), then use
+    the package name (e.g. 'a.b' from the example 'a.b.c'), and use the final module name
+    as the protocol name (e.g. 'c').
+    """
+    parts = protocol.split('.')
+    if len(parts) > 1 and '' not in parts:
+        # Treat the protocol as a full Python package name/path followed by the protocol name.
+        protocol = parts[-1]
+        packages = ['.'.join(parts[0:-1])]
+    module_name = '.protocol_{}'.format(protocol)
+    for package_name in packages:
+        try:
+            importlib.import_module(package_name)
+            return importlib.import_module(module_name, package_name)
+        except ImportError:
+            continue
+    return None
+
+
 def serial_for_url(url, *args, **kwargs):
     """\
     Get an instance of the Serial class, depending on port/url. The port is not
@@ -66,19 +88,12 @@ def serial_for_url(url, *args, **kwargs):
         # if it is an URL, try to import the handler module from the list of possible packages
         if '://' in url_lowercase:
             protocol = url_lowercase.split('://', 1)[0]
-            module_name = '.protocol_{}'.format(protocol)
-            for package_name in protocol_handler_packages:
-                try:
-                    importlib.import_module(package_name)
-                    handler_module = importlib.import_module(module_name, package_name)
-                except ImportError:
-                    continue
+            handler_module = _find_module_for_protocol(protocol, protocol_handler_packages)
+            if handler_module:
+                if hasattr(handler_module, 'serial_class_for_url'):
+                    url, klass = handler_module.serial_class_for_url(url)
                 else:
-                    if hasattr(handler_module, 'serial_class_for_url'):
-                        url, klass = handler_module.serial_class_for_url(url)
-                    else:
-                        klass = handler_module.Serial
-                    break
+                    klass = handler_module.Serial
             else:
                 raise ValueError('invalid URL, protocol {!r} not known'.format(protocol))
     # instantiate and open when desired

--- a/test/test_url.py
+++ b/test/test_url.py
@@ -14,8 +14,10 @@ the code.
 Cover some of the aspects of serial_for_url and the extension mechanism.
 """
 
+import os
 import unittest
 import serial
+import sys
 
 
 class Test_URL(unittest.TestCase):
@@ -41,6 +43,38 @@ class Test_URL(unittest.TestCase):
         serial.protocol_handler_packages.remove('handlers')
         # so it should not work anymore
         self.assertRaises(ValueError, serial.serial_for_url, "test://")
+
+    def test_fully_qualified_custom_url(self):
+        """custom protocol handlers with fully qualified names"""
+        old_path = list(sys.path)
+        try:
+            # For serial_for_url('handlers.test://') to work, sys.path needs
+            # to include the parent of the top-level package; handlers is that
+            # package in this case, and this test's directory is the parent of
+            # that package.
+            this_dir = os.path.dirname(os.path.abspath(__file__))
+
+            # Make sure that sys.path does not include this_dir. Start by making the path
+            # absolute.
+            sys.path = [os.path.abspath(v) for v in sys.path]
+            sys.path = [v for v in sys.path if not v == this_dir]
+
+            # Because of the other tests, the module will already be imported, so remove it.
+            if 'handlers' in sys.modules:
+                del sys.modules['handlers']
+            if 'handlers.test' in sys.modules:
+                del sys.modules['handlers.test']
+
+            # It's unknown because sys.path doesn't include this_dir.
+            self.assertRaises(ValueError, serial.serial_for_url, "handlers.test://")
+
+            # Add this_dir to sys.path.
+            sys.path.insert(0, this_dir)
+
+            # now it should work
+            serial.serial_for_url("handlers.test://")
+        finally:
+            sys.path = old_path
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses #294, and probably fully addresses #292.