### PR TITLE
Update list_ports_common.py

### DIFF
--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -72,7 +72,7 @@ class ListPortInfo(object):
         self.hwid = self.usb_info()
 
     def __eq__(self, other):
-        return self.device == other.device
+        return hasattr(other, 'device') and self.device == other.device
 
     def __lt__(self, other):
         return numsplit(self.device) < numsplit(other.device)


### PR DESCRIPTION
Fixes AttributeError if a port is compared to another object (ex a string)
```
serial/tools/list_ports_common.py", line 74, in __eq__
    return self.device == other.device
AttributeError: 'NoneType' object has no attribute 'device'
```