### PR TITLE
Skip link detection in Windows

### DIFF
--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -11,7 +11,7 @@ import re
 import glob
 import os
 import os.path
-
+import platform
 
 def numsplit(text):
     """\
@@ -46,7 +46,8 @@ class ListPortInfo(object):
         self.product = None
         self.interface = None
         # special handling for links
-        if device is not None and os.path.islink(device):
+        # (Not required in Windows. Skip because os.path.islink can be really slow there)
+        if platform.system() != "Windows" and device is not None and os.path.islink(device):
             self.hwid = 'LINK={}'.format(os.path.realpath(device))
 
     def usb_description(self):


### PR DESCRIPTION
If `p` is a Serial over Bluetooth link, then `os.path.islink(p)` may take several seconds.

In two of my Windows 10 computers following code used to take 5 seconds:

```
from serial.tools.list_ports import comports
for p in comports():
    print(p)
```
I found out that the delay was caused by `os.path.islink('COM5')`. COM5 is one of the "Bluetooth over serial" ports backed by LogiLink Bluetooth dongle.

After my change it takes 0.01 seconds.

If I'm not mistaken, then `list_ports_windows` can't list symlinks anyway, so this time consuming check can be turned off for Windows.