### PR TITLE
return b'' when connection closes on rfc2217 connection

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -613,7 +613,10 @@ class Serial(SerialBase):
             while len(data) < size:
                 if self._thread is None:
                     raise SerialException('connection failed (reader thread died)')
-                data += self._read_buffer.get(True, timeout.time_left())
+                buf = self._read_buffer.get(True, timeout.time_left())
+                if buf is None:
+                    return bytes(data)
+                data += buf
                 if timeout.expired():
                     break
         except Queue.Empty:  # -> timeout
@@ -738,8 +741,10 @@ class Serial(SerialBase):
                     # connection fails -> terminate loop
                     if self.logger:
                         self.logger.debug("socket error in reader thread: {}".format(e))
+                    self._read_buffer.put(None)
                     break
                 if not data:
+                    self._read_buffer.put(None)
                     break  # lost connection
                 for byte in iterbytes(data):
                     if mode == M_NORMAL:


### PR DESCRIPTION
Return an empty bytes object when the rfc2217 connection closes. This way the behavior is the same as closing a normal serial port. 