### PR TITLE
Use absolute import everywhere

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 import sys
 import importlib
 

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -58,6 +58,8 @@
 #   RFC).
 # the order of the options is not relevant
 
+from __future__ import absolute_import
+
 import logging
 import socket
 import struct

--- a/serial/rs485.py
+++ b/serial/rs485.py
@@ -13,6 +13,8 @@ serial ports (where supported).
 NOTE: Some implementations may only support a subset of the settings.
 """
 
+from __future__ import absolute_import
+
 import time
 import serial
 

--- a/serial/serialcli.py
+++ b/serial/serialcli.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 import System
 import System.IO.Ports
 from serial.serialutil import *

--- a/serial/serialjava.py
+++ b/serial/serialjava.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 from serial.serialutil import *
 
 

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -26,6 +26,8 @@
 # - aix (AIX)               /dev/tty%d
 
 
+from __future__ import absolute_import
+
 # pylint: disable=abstract-method
 import errno
 import fcntl

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 import io
 import time
 

--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -9,6 +9,8 @@
 #
 # Initial patch to use ctypes by Giovanni Bajo <rasky@develer.com>
 
+from __future__ import absolute_import
+
 # pylint: disable=invalid-name,too-few-public-methods
 import ctypes
 import time

--- a/serial/threaded/__init__.py
+++ b/serial/threaded/__init__.py
@@ -9,6 +9,8 @@
 """\
 Support threading with serial ports.
 """
+from __future__ import absolute_import
+
 import serial
 import threading
 

--- a/serial/tools/hexlify_codec.py
+++ b/serial/tools/hexlify_codec.py
@@ -18,6 +18,8 @@ Therefore decoding is binary to text and thus converting binary data to hex dump
 
 """
 
+from __future__ import absolute_import
+
 import codecs
 import serial
 

--- a/serial/tools/list_ports.py
+++ b/serial/tools/list_ports.py
@@ -16,6 +16,8 @@ Additionally a grep function is supplied that can be used to search for ports
 based on their descriptions or hardware ID.
 """
 
+from __future__ import absolute_import
+
 import sys
 import os
 import re

--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -7,6 +7,9 @@
 # (C) 2015 Chris Liechti <cliechti@gmx.net>
 #
 # SPDX-License-Identifier:    BSD-3-Clause
+
+from __future__ import absolute_import
+
 import re
 import glob
 import os

--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -8,6 +8,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 import glob
 import os
 from serial.tools import list_ports_common

--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -21,6 +21,8 @@
 
 # Also see the 'IORegistryExplorer' for an idea of what we are actually searching
 
+from __future__ import absolute_import
+
 import ctypes
 import ctypes.util
 

--- a/serial/tools/list_ports_posix.py
+++ b/serial/tools/list_ports_posix.py
@@ -16,6 +16,8 @@ As currently no method is known to get the second two strings easily, they are
 currently just identical to the port name.
 """
 
+from __future__ import absolute_import
+
 import glob
 import sys
 import os

--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -8,6 +8,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 # pylint: disable=invalid-name,too-few-public-methods
 import re
 import ctypes

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -7,6 +7,8 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 import codecs
 import os
 import sys

--- a/serial/urlhandler/protocol_alt.py
+++ b/serial/urlhandler/protocol_alt.py
@@ -16,6 +16,8 @@
 #   use poll based implementation on Posix (Linux):
 #   python -m serial.tools.miniterm alt:///dev/ttyUSB0?class=PosixPollSerial
 
+from __future__ import absolute_import
+
 try:
     import urlparse
 except ImportError:

--- a/serial/urlhandler/protocol_hwgrep.py
+++ b/serial/urlhandler/protocol_hwgrep.py
@@ -20,6 +20,8 @@
 # n=<N>     pick the N'th entry instead of the first one (numbering starts at 1)
 # skip_busy tries to open port to check if it is busy, fails on posix as ports are not locked!
 
+from __future__ import absolute_import
+
 import serial
 import serial.tools.list_ports
 

--- a/serial/urlhandler/protocol_loop.py
+++ b/serial/urlhandler/protocol_loop.py
@@ -13,6 +13,8 @@
 # URL format:    loop://[option[/option...]]
 # options:
 # - "debug" print diagnostic messages
+from __future__ import absolute_import
+
 import logging
 import numbers
 import time

--- a/serial/urlhandler/protocol_rfc2217.py
+++ b/serial/urlhandler/protocol_rfc2217.py
@@ -7,4 +7,6 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 
+from __future__ import absolute_import
+
 from serial.rfc2217 import Serial  # noqa

--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -16,6 +16,8 @@
 # options:
 # - "debug" print diagnostic messages
 
+from __future__ import absolute_import
+
 import errno
 import logging
 import select

--- a/serial/urlhandler/protocol_spy.py
+++ b/serial/urlhandler/protocol_spy.py
@@ -20,6 +20,8 @@
 #   redirect output to an other terminal window on Posix (Linux):
 #   python -m serial.tools.miniterm spy:///dev/ttyUSB0?dev=/dev/pts/14\&color
 
+from __future__ import absolute_import
+
 import sys
 import time
 

--- a/serial/win32.py
+++ b/serial/win32.py
@@ -9,6 +9,8 @@
 
 # pylint: disable=invalid-name,too-few-public-methods,protected-access,too-many-instance-attributes
 
+from __future__ import absolute_import
+
 from ctypes import c_ulong, c_void_p, c_int64, c_char, \
                    WinDLL, sizeof, Structure, Union, POINTER
 from ctypes.wintypes import HANDLE


### PR DESCRIPTION
This prevents Python 2.7 from attempting -- and failing -- to import system modules like sys and ctypes from the ``serial/`` directory.

At the company I work for, we're running Python 2.7 instances from a Windows share. Absolute imports in our production software have reduced system module import misses by 1000 per run. I'm going through third-party modules to further reduce the import misses. =)

Please let me know if you see anything out of place or need me to make any changes to get this patch accepted! I ran the unit tests on Windows and they continued to pass but let me know if I missed something. Thanks!