### PR TITLE
Update conda version in pyserial.rst

### DIFF
--- a/documentation/pyserial.rst
+++ b/documentation/pyserial.rst
@@ -86,7 +86,7 @@ pySerial can be installed from Conda::
     
     conda install -c conda-forge pyserial
     
-Currently the default conda channel will provide version 2.7 whereas the
+Currently the default conda channel will provide version 3.4 whereas the
 conda-forge channel provides the current 3.x version.
 
 Conda: https://www.continuum.io/downloads


### PR DESCRIPTION
Checked the version against conda today, looks like it's pyserial 3.4.

```
In [1]: import serial

In [2]: serial.__version__
Out[2]: '3.4'
```