### PR TITLE
Fix miniterm constructor defaults for exit_character and menu_character variables

### DIFF
--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -347,8 +347,8 @@ class Miniterm(object):
         self.eol = eol
         self.filters = filters
         self.update_transformations()
-        self.exit_character = 0x1d  # GS/CTRL+]
-        self.menu_character = 0x14  # Menu: CTRL+T
+        self.exit_character = unichr(0x1d)  # GS/CTRL+]
+        self.menu_character = unichr(0x14)  # Menu: CTRL+T
         self.alive = None
         self._reader_alive = None
         self.receiver_thread = None


### PR DESCRIPTION
The MiniTerm.writer() method expects the exit_character and menu_character in character format instead of integer.
The main() function works because both member variables are overwritten with the correct format, any other programs using the default values from the constructor won't be able to exit or view the menu.