### PR TITLE
setup.py: Add install-time check for conflicting 'serial' package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,24 @@ try:
 except ImportError:
     from distutils.core import setup
 
+try:
+    import pkg_resources
+    try:
+        pkg_resources.get_distribution('serial')
+        raise RuntimeError(
+            """This package cannot be installed alongside `serial`, due to a module name conflict.
+To install `pyserial`, first uninstall `serial`:
+>>> pip uninstall serial
+>>> pip install pyserial
+...or:
+>>> pip3 uninstall serial
+>>> pip3 install pyserial"""
+        )
+    except pkg_resources.DistributionNotFound:
+        pass
+except ImportError:
+    pass  # pkg_resources is part of setuptools, may not be available
+
 
 def read(*names, **kwargs):
     """Python 2 and Python 3 compatible text file reading.


### PR DESCRIPTION
Addresses https://github.com/pyserial/pyserial/issues/319

This is derived closely from the equivalent check applied by @davebelais to
'serial', here:
https://bitbucket.org/davebelais/serial/commits/363abb1c5d92dfdb3f1b3e3af70fee28bd05e053#Lsetup.pyT1

This doesn't fix issues in code which uses 'pyserial', in cases where 'serial'
was accidentally installed on the system instead. But it prevents issues caused
when both packages are installed at once.

Thanks for all your hard work on pyserial. It's a great package.