### PR TITLE
Fixed the docstring for the set_buffer_size function. 

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -418,7 +418,7 @@ class Serial(SerialBase):
     def set_buffer_size(self, rx_size=4096, tx_size=None):
         """\
         Recommend a buffer size to the driver (device driver can ignore this
-        value). Must be called before the port is opened.
+        value). Must be called after the port is opened.
         """
         if tx_size is None:
             tx_size = rx_size


### PR DESCRIPTION
Fixed the docstring for the set_buffer_size function. It should be called after the port is opened otherwise it will be overwritten