### PR TITLE
Working CMD.exe terminal using Windows 10 ANSI support

### DIFF
--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -134,7 +134,8 @@ if os.name == 'nt':  # noqa
             self._saved_icp = ctypes.windll.kernel32.GetConsoleCP()
             ctypes.windll.kernel32.SetConsoleOutputCP(65001)
             ctypes.windll.kernel32.SetConsoleCP(65001)
-            # ANSI handling available through SetConsoleMode since v1511 https://en.wikipedia.org/wiki/ANSI_escape_code#cite_note-win10th2-1
+            # ANSI handling available through SetConsoleMode since Windows 10 v1511 
+            # https://en.wikipedia.org/wiki/ANSI_escape_code#cite_note-win10th2-1
             if platform.release() == '10' and int(platform.version().split('.')[2]) > 10586:
                 ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
                 import ctypes.wintypes as wintypes

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -1037,4 +1037,3 @@ def main(default_port=None, default_baudrate=9600, default_rts=None, default_dtr
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
This pull should enable a working terminal on Windows 10 with all main control keys supported and proper console behaviours as demonstrated by connecting to a Micropython ESP8266 Vanguard board ( https://vgkits.org/blog/vanguard/ ) over USB  like...

```
python -m serial.tools.miniterm --filter direct --eol CRLF --encoding utf-8 COM3 115200
```

This is a rollup of changes to introduce detection and configuration of ANSI support (available in Windows 10 since 2015) a fix for https://github.com/pyserial/pyserial/issues/350 and a merge of ANSI-mapping features from https://github.com/zsquareplusc/mpy-repl-tool/  ( [miniterm_mpy.py](https://github.com/zsquareplusc/mpy-repl-tool/raw/master/there/miniterm_mpy.py) ).
