### PR TITLE
Documented read_until function

### DIFF
--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -157,6 +157,22 @@ Native ports
             Returns an instance of :class:`bytes` when available (Python 2.6
             and newer) and :class:`str` otherwise.
 
+    .. method:: read_until(expected=LF, size=None)
+
+        :param expected: The byte string to search for.
+        :param size: Number of bytes to read.
+        :return: Bytes read from the port.
+        :rtype: bytes
+
+        Read until an expected sequence is found ('\n' by default), the size
+        is exceeded or until timeout occurs. If a timeout is set it may
+        return less characters as requested. With no timeout it will block
+        until the requested number of bytes is read.
+
+        .. versionchanged:: 2.5
+            Returns an instance of :class:`bytes` when available (Python 2.6
+            and newer) and :class:`str` otherwise.
+
     .. method:: write(data)
 
         :param data: Data to send.

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -649,19 +649,19 @@ class SerialBase(io.RawIOBase):
         """
         return self.read(self.in_waiting)
 
-    def read_until(self, terminator=LF, size=None):
+    def read_until(self, expected=LF, size=None):
         """\
-        Read until a termination sequence is found ('\n' by default), the size
+        Read until an expected sequence is found ('\n' by default), the size
         is exceeded or until timeout occurs.
         """
-        lenterm = len(terminator)
+        lenterm = len(expected)
         line = bytearray()
         timeout = Timeout(self._timeout)
         while True:
             c = self.read(1)
             if c:
                 line += c
-                if line[-lenterm:] == terminator:
+                if line[-lenterm:] == expected:
                     break
                 if size is not None and len(line) >= size:
                     break


### PR DESCRIPTION
I end up writing my own flavor of read_until every time to line up with telnetlib.  Didn't know it was apart of pyserial already!  Documented the function.  I also tweaked the parameter name to match telnetlib but it is not affecting anything if that is left as terminator.