### PR TITLE
Add list_ports and miniterm entry points

### DIFF
--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -93,7 +93,7 @@ Testing ports
 =============
 Listing ports
 -------------
-``python -m serial.tools.list_ports`` will print a list of available ports. It
+``list_ports`` will print a list of available ports. It
 is also possible to add a regexp as first argument and the list will only
 include entries that matched.
 
@@ -104,9 +104,12 @@ include entries that matched.
     ports.
 
 .. versionadded: 2.6
+.. versionchanged: 3.5 added ``list_ports`` entry point
 
 Accessing ports
 ---------------
 pySerial includes a small console based terminal program called
-:ref:`miniterm`.  It can be started with ``python -m serial.tools.miniterm <port_name>``
+:ref:`miniterm`.  It can be started with ``miniterm <port_name>``
 (use option ``-h`` to get a listing of all options).
+
+.. versionchanged: 3.5 added ``miniterm`` entry point

--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -9,7 +9,8 @@ serial.tools.list_ports
 .. module:: serial.tools.list_ports
 
 This module can be executed to get a list of ports (``python -m
-serial.tools.list_ports``). It also contains the following functions.
+serial.tools.list_ports``, ``list_ports`` entry point).
+It also contains the following functions.
 
 
 .. function:: comports(include_links=False)
@@ -123,9 +124,9 @@ serial.tools.list_ports``). It also contains the following functions.
 
 **Command line usage**
 
-Help for ``python -m serial.tools.list_ports``::
+Help for ``list_ports``::
 
-    usage: list_ports.py [-h] [-v] [-q] [-n N] [-s] [regexp]
+    usage: list_ports [-h] [-v] [-q] [-n N] [-s] [regexp]
 
     Serial port enumeration
 
@@ -144,7 +145,7 @@ Examples:
 
 - List all ports with details::
 
-    $ python -m serial.tools.list_ports -v
+    $ list_ports -v
     /dev/ttyS0
         desc: ttyS0
         hwid: PNP0501
@@ -156,11 +157,12 @@ Examples:
 
 - List the 2nd port matching a USB VID:PID pattern::
 
-    $ python -m serial.tools.list_ports 1234:5678 -q -n 2
+    $ list_ports 1234:5678 -q -n 2
     /dev/ttyUSB1
 
 .. versionadded:: 2.6
 .. versionchanged:: 3.0 returning ``ListPortInfo`` objects instead of a tuple
+.. versionchanged:: 3.5 ``list_ports`` entry point added
 
 
 .. _miniterm:
@@ -192,13 +194,13 @@ Miniterm supports :rfc:`2217` remote serial ports and raw sockets using :ref:`UR
 such as ``rfc2217://<host>:<port>`` respectively ``socket://<host>:<port>`` as
 *port* argument when invoking.
 
-Command line options ``python -m serial.tools.miniterm -h``::
+Command line options ``miniterm -h``::
 
-    usage: miniterm.py [-h] [--parity {N,E,O,S,M}] [--rtscts] [--xonxoff]
-                       [--rts RTS] [--dtr DTR] [-e] [--encoding CODEC] [-f NAME]
-                       [--eol {CR,LF,CRLF}] [--raw] [--exit-char NUM]
-                       [--menu-char NUM] [-q] [--develop]
-                       [port] [baudrate]
+    usage: miniterm [-h] [--parity {N,E,O,S,M}] [--rtscts] [--xonxoff]
+                    [--rts RTS] [--dtr DTR] [-e] [--encoding CODEC] [-f NAME]
+                    [--eol {CR,LF,CRLF}] [--raw] [--exit-char NUM]
+                    [--menu-char NUM] [-q] [--develop]
+                    [port] [baudrate]
 
     Miniterm - A simple terminal program for the serial port.
 
@@ -287,4 +289,4 @@ also possible to exit (:kbd:`Ctrl+]`) or change the port (:kbd:`p`).
     Apply encoding on serial port, convert to Unicode for console.
     Added new filters, default to stripping terminal control sequences.
     Added ``--ask`` option.
-
+.. versionchanged:: 3.5 ``miniterm`` entry point added

--- a/documentation/url_handlers.rst
+++ b/documentation/url_handlers.rst
@@ -202,7 +202,7 @@ device (e.g. with the ``ps`` command in the TTY column), assumed to be
 ``/dev/pts/2`` here, double quotes are used so that the ampersand in the URL is
 not interpreted by the shell::
 
-    python -m serial.tools.miniterm "spy:///dev/ttyUSB0?file=/dev/pts/2&color" 115200
+    miniterm "spy:///dev/ttyUSB0?file=/dev/pts/2&color" 115200
 
 The spy output will be live in the second terminal window.
 

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,7 @@ import io
 import os
 import re
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 
 def read(*names, **kwargs):
@@ -97,4 +94,10 @@ Latest:
     ],
     platforms='any',
     scripts=['serial/tools/miniterm.py'],
+    entry_points={
+        'console_scripts': [
+            'miniterm = serial.tools.miniterm:main',
+            'list_ports = serial.tools.list_ports:main',
+        ],
+    }
 )


### PR DESCRIPTION
Note, this also removes support for bare `distutils` in setup.py

`setuptools` is now so ubiquitous (pip uses it even if it is not imported directly) that I do not see this as a problem, but I can refactor to include if it is desired to keep this functionality.

entry_points are a tool specific to `setuptools`

I also had to guess at the next version for the ``versionchanged`` in the docs