### PR TITLE
Mac and bsd fix _update_break_state

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -15,7 +15,7 @@ import importlib
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-__version__ = '3.4'
+__version__ = '3.4.1'
 
 VERSION = __version__
 

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -53,6 +53,15 @@ class PlatformSpecificBase(object):
 
     def set_low_latency_mode(self, low_latency_settings):
         raise NotImplementedError('Low latency not supported on this platform')
+
+    def _update_break_state(self):
+        """\
+        Set break: Controls TXD. When active, no transmitting is possible.
+        """
+        if self._break_state:
+            fcntl.ioctl(self.fd, TIOCSBRK)
+        else:
+            fcntl.ioctl(self.fd, TIOCCBRK)
     
 
 # some systems support an extra flag to enable the two in POSIX unsupported
@@ -659,15 +668,6 @@ class Serial(SerialBase, PlatformSpecific):
         if not self.is_open:
             raise portNotOpenError
         termios.tcsendbreak(self.fd, int(duration / 0.25))
-
-    def _update_break_state(self):
-        """\
-        Set break: Controls TXD. When active, no transmitting is possible.
-        """
-        if self._break_state:
-            fcntl.ioctl(self.fd, TIOCSBRK)
-        else:
-            fcntl.ioctl(self.fd, TIOCCBRK)
 
     def _update_rts_state(self):
         """Set terminal status line: Request To Send"""

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -202,11 +202,12 @@ elif plat == 'cygwin':       # cygwin/win32 (confirmed)
 elif plat[:6] == 'darwin':   # OS X
     import array
     IOSSIOSPEED = 0x80045402  # _IOW('T', 2, speed_t)
-    TIOCSBRK = 0x2000747B # _IO('t', 123)
-    TIOCCBRK = 0x2000747A # _IO('t', 122)
 
     class PlatformSpecific(PlatformSpecificBase):
         osx_version = os.uname()[2].split('.')
+        TIOCSBRK = 0x2000747B # _IO('t', 123)
+        TIOCCBRK = 0x2000747A # _IO('t', 122)
+
         # Tiger or above can support arbitrary serial speeds
         if int(osx_version[0]) >= 8:
             def _set_special_baudrate(self, baudrate):
@@ -219,9 +220,9 @@ elif plat[:6] == 'darwin':   # OS X
             Set break: Controls TXD. When active, no transmitting is possible.
             """
             if self._break_state:
-                fcntl.ioctl(self.fd, TIOCSBRK)
+                fcntl.ioctl(self.fd, PlatformSpecific.TIOCSBRK)
             else:
-                fcntl.ioctl(self.fd, TIOCCBRK)
+                fcntl.ioctl(self.fd, PlatformSpecific.TIOCCBRK)
 
 elif plat[:3] == 'bsd' or \
      plat[:7] == 'freebsd' or \
@@ -237,6 +238,19 @@ elif plat[:3] == 'bsd' or \
         # The baud rate may be passed in as
         # a literal value.
         BAUDRATE_CONSTANTS = ReturnBaudrate()
+
+        TIOCSBRK = 0x2000747B # _IO('t', 123)
+        TIOCCBRK = 0x2000747A # _IO('t', 122)
+
+        
+        def _update_break_state(self):
+            """\
+            Set break: Controls TXD. When active, no transmitting is possible.
+            """
+            if self._break_state:
+                fcntl.ioctl(self.fd, PlatformSpecific.TIOCSBRK)
+            else:
+                fcntl.ioctl(self.fd, PlatformSpecific.TIOCCBRK)
 
 else:
     class PlatformSpecific(PlatformSpecificBase):


### PR DESCRIPTION
Fixes #366 

These values were pulled from the system <ioctl.h> headers on mac. As such this should allow the .break_condition to be set on mac and bsd based systems.

I implemented this functionality by duplicating the code within the two platform specific sections for 'darwin' and 'bsd'.