### PR TITLE
Add support for green threads

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -36,6 +36,7 @@ import select
 import struct
 import sys
 import termios
+import time 
 
 import serial
 from serial.serialutil import SerialBase, SerialException, to_bytes, \
@@ -538,6 +539,10 @@ class Serial(SerialBase, PlatformSpecific):
                     raise SerialException('read failed: {}'.format(e))
             if timeout.expired():
                 break
+
+        # Give an opportunity to switch a context. It prevents deadlock if 
+        # a greenthread is used (e.g. after eventlet.monkey_patch()).  
+        time.sleep(0)
         return bytes(read)
 
     def cancel_read(self):

--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -298,6 +298,10 @@ class Serial(SerialBase):
                 read = bytes()
         else:
             read = bytes()
+
+        # Give an opportunity to switch a context. It prevents deadlock if 
+        # a greenthread is used (e.g. after eventlet.monkey_patch()).
+        time.sleep(0)
         return bytes(read)
 
     def write(self, data):


### PR DESCRIPTION
Today I noticed that the serial.read() causes a deadlock when the threading library is monkey_patched by e.g. eventlet (threads in cooperative mode against parallel) even when timeout is specified. Example:
```
STOP = False

def test():
    global STOP
    sh = serial.Serial('COM1', timeout=.1)
    while not STOP:
        sh.read(1)

threading.Thread(target=test, daemon=True).start()
time.sleep(1)
STOP = True
#thread will be killed

#but in case of:
eventlet.monkey_patch()
threading.Thread(target=test, daemon=True).start()
#program will never reach the point below!
STOP = True
```

The solution is a little bit tricky. time.sleep(0) won't cause any time delay but allows to switch context and solves the problem. 