### PR TITLE
Removed Errant `open()` Call in Context Mgr Docs

### DIFF
--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -49,7 +49,6 @@ Also supported with :ref:`context manager <context-manager>`::
     with serial.Serial() as ser:
         ser.baudrate = 19200
         ser.port = 'COM1'
-        ser.open()
         ser.write(b'hello')
 
 


### PR DESCRIPTION
If you try to execute this code as is you will get:

```python
SerialException: Port is already open.
```

since the context manager already opens the port on entry