### PR TITLE
rfc2217/close(): fix race condition

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -613,7 +613,7 @@ class Serial(SerialBase):
         try:
             timeout = Timeout(self._timeout)
             while len(data) < size:
-                if self._thread is None:
+                if self._thread is None or not self._thread.is_alive():
                     raise SerialException('connection failed (reader thread died)')
                 buf = self._read_buffer.get(True, timeout.time_left())
                 if buf is None:
@@ -790,7 +790,6 @@ class Serial(SerialBase):
                         self._telnet_negotiate_option(telnet_command, byte)
                         mode = M_NORMAL
         finally:
-            self._thread = None
             if self.logger:
                 self.logger.debug("read thread terminated")
 


### PR DESCRIPTION
When stopping the read loop, do not set `self._thread = None` inside the thread itself as there may be a race-condition with the method close().

The method close() closes the socket, which stops the read loop. When the read loop stops, it set `self._thread` to `None`, but if it sets it to `None` while close() is right between between the execution of `if self._thread:` and `self._thread.join()`, close() will raise an AttributeError.
