### PR TITLE
Replaced RFC 2271 with 2217 in docs & comments

### DIFF
--- a/documentation/url_handlers.rst
+++ b/documentation/url_handlers.rst
@@ -48,7 +48,7 @@ Supported options in the URL are:
 
 - ``timeout=<value>``: Change network timeout (default 3 seconds). This is
   useful when the server takes a little more time to send its answers. The
-  timeout applies to the initial Telnet / :rfc:`2271` negotiation as well
+  timeout applies to the initial Telnet / :rfc:`2217` negotiation as well
   as changing port settings or control line change commands.
 
 - ``logging={debug|info|warning|error}``: Prints diagnostic messages (not

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -483,7 +483,7 @@ class Serial(SerialBase):
             if self.logger:
                 self.logger.info("Negotiated options: {}".format(self._telnet_options))
 
-            # fine, go on, set RFC 2271 specific things
+            # fine, go on, set RFC 2217 specific things
             self._reconfigure_port()
             # all things set up get, now a clean start
             if not self._dsrdtr:

--- a/serial/urlhandler/protocol_rfc2217.py
+++ b/serial/urlhandler/protocol_rfc2217.py
@@ -1,6 +1,6 @@
 #! python
 #
-# This is a thin wrapper to load the rfc2271 implementation.
+# This is a thin wrapper to load the rfc2217 implementation.
 #
 # This file is part of pySerial. https://github.com/pyserial/pyserial
 # (C) 2011 Chris Liechti <cliechti@gmx.net>


### PR DESCRIPTION
Fixed transposed RFC 2217 (was 2271)  

Updated docs and comments incorrectly referencing 2271 (SNMP).  No code change.