### PR TITLE
Add WaitCommEvent function to win32

### DIFF
--- a/serial/win32.py
+++ b/serial/win32.py
@@ -181,6 +181,10 @@ WaitForSingleObject = _stdcall_libraries['kernel32'].WaitForSingleObject
 WaitForSingleObject.restype = DWORD
 WaitForSingleObject.argtypes = [HANDLE, DWORD]
 
+WaitCommEvent = _stdcall_libraries['kernel32'].WaitCommEvent
+WaitCommEvent.restype = BOOL
+WaitCommEvent.argtypes = [HANDLE, LPDWORD, LPOVERLAPPED]
+
 CancelIoEx = _stdcall_libraries['kernel32'].CancelIoEx
 CancelIoEx.restype = BOOL
 CancelIoEx.argtypes = [HANDLE, LPOVERLAPPED]
@@ -246,6 +250,12 @@ EV_CTS = 8  # Variable c_int
 EV_BREAK = 64  # Variable c_int
 PURGE_RXCLEAR = 8  # Variable c_int
 INFINITE = 0xFFFFFFFF
+
+CE_RXOVER = 0x0001
+CE_OVERRUN = 0x0002
+CE_RXPARITY = 0x0004
+CE_FRAME = 0x0008
+CE_BREAK = 0x0010
 
 
 class N11_OVERLAPPED4DOLLAR_48E(Union):


### PR DESCRIPTION
This is helpful when a user wants to wait for some kind of communication event. E.g. listening for parity errors, etc.