### PR TITLE
Update serialutil.py

### DIFF
--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -650,7 +650,7 @@ class SerialBase(io.RawIOBase):
         return self.read(self.in_waiting)
 
     def read_until(self, expected=LF, size=None):
-        """\
+        r"""\
         Read until an expected sequence is found ('\n' by default), the size
         is exceeded or until timeout occurs.
         """


### PR DESCRIPTION
https://stackoverflow.com/questions/33734170/why-doesnt-python-auto-escape-in-doc
https://www.python.org/dev/peps/pep-0257/#specification

  For consistency, always use """triple double quotes""" around docstrings. Use r"""raw triple double quotes""" if you use any backslashes in your docstrings. For Unicode docstrings, use u"""Unicode triple-quoted strings""".