### PR TITLE
Handle FramedPacket.START bytes within a packet

### DIFF
--- a/serial/threaded/__init__.py
+++ b/serial/threaded/__init__.py
@@ -100,7 +100,7 @@ class FramedPacket(Protocol):
     def data_received(self, data):
         """Find data enclosed in START/STOP, call handle_packet"""
         for byte in serial.iterbytes(data):
-            if byte == self.START:
+            if byte == self.START and not self.in_packet:
                 self.in_packet = True
             elif byte == self.STOP:
                 self.in_packet = False


### PR DESCRIPTION
If we are inside a packet, the current logic skips over any bytes that match the START byte. I believe the correct behaviour would be to include all bytes since the first START byte up until the STOP byte, as proposed here