### PR TITLE
Correct "interface" property on Linux hosts

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -59,7 +59,7 @@ class SysFS(list_ports_common.ListPortInfo):
 
             self.manufacturer = self.read_line(self.usb_device_path, 'manufacturer')
             self.product = self.read_line(self.usb_device_path, 'product')
-            self.interface = self.read_line(self.device_path, 'interface')
+            self.interface = self.read_line(self.usb_interface_path, 'interface')
 
         if self.subsystem in ('usb', 'usb-serial'):
             self.apply_usb_info()


### PR DESCRIPTION
The "interface" property should be read from the "usb_interface_path"
instead of the "device_path" as the later one is a directory (e.g.
/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2/1-2.3/1-2.3:1.0/ttyUSB1).

This has been tested together with an CP2105EK where it is important
to separate the serial ports from each other.