### PR TITLE
Dropping python 3.2 and 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist
 *.egg-info
 
 /MANIFEST
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ language: python
 
 python:
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - 3.6


### PR DESCRIPTION
As previously mentioned in #499 and #476 this pull request is for dropping older python versions that are not available on travis anymore