### PR TITLE
fix: stop reusing exception instances

### DIFF
--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -97,8 +97,18 @@ class SerialTimeoutException(SerialException):
     """Write timeouts give an exception"""
 
 
-writeTimeoutError = SerialTimeoutException('Write timeout')
-portNotOpenError = SerialException('Attempting to use a port that is not open')
+class WriteTimeoutError(SerialTimeoutException):
+    def __init__(self):
+        super(WriteTimeoutError, self).__init__('Write timeout')
+
+
+class PortNotOpenError(SerialException):
+    def __init__(self):
+        super(PortNotOpenError, self).__init__('Attempting to use a port that is not open')
+
+
+writeTimeoutError = WriteTimeoutError
+portNotOpenError = PortNotOpenError
 
 
 class Timeout(object):


### PR DESCRIPTION
writeTimeoutError and portNotOpenError ware precreated exception
instances. When rising these exceptions multiple times, stack trace
was appended to existing traces. This leads to two issues

 - no easy to debug real cause of the exception because of wrong
   stack trace
 - memory leak, because stack trace is never cleared. Raising
   portNotOpenError multiple times (understand e.g. one milion
   times, for long running script, it is perfectly possible)
   will cause out of memory

this change just assign specially crafted exception classes to
existing writeTimeoutError and portNotOpenError variables so
they will produce identical message but they are no longer
precreated.

New exceptions are derived from original SerialTimeoutException
and SerialException so existing user code should not break by this
change

closes: #437