### PR TITLE
linux: Fix custom baud rate to not temporarily set 38400 baud rates

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -405,8 +405,15 @@ class Serial(SerialBase, PlatformSpecific):
                 ispeed = ospeed = self.BAUDRATE_CONSTANTS[self._baudrate]
             except KeyError:
                 #~ raise ValueError('Invalid baud rate: %r' % self._baudrate)
-                # may need custom baud rate, it isn't in our list.
-                ispeed = ospeed = getattr(termios, 'B38400')
+
+                # See if BOTHER is defined for this platform; if it is, use
+                # this for a speed not defined in the baudrate constants list.
+                try:
+                    ispeed = ospeed = BOTHER
+                except NameError:
+                    # may need custom baud rate, it isn't in our list.
+                    ispeed = ospeed = getattr(termios, 'B38400')
+
                 try:
                     custom_baud = int(self._baudrate)  # store for later
                 except ValueError:


### PR DESCRIPTION
When using a custom baud rate on Linux these lines of code caused it
to push a 38400 baud rate setting down into the serial driver (even
if temporarily).  It would correct this moments later, but we can
simply set the BOTHER value at this point.  If other platforms have
a different default value for ispeed and ospeed when using a custom baud
rate, they can define BOTHER as well.