### PR TITLE
fix issue 509 - kIOMasterPortDefault no longer exported on Big Sur

### DIFF
--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -30,7 +30,8 @@ from serial.tools import list_ports_common
 iokit = ctypes.cdll.LoadLibrary('/System/Library/Frameworks/IOKit.framework/IOKit')
 cf = ctypes.cdll.LoadLibrary('/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation')
 
-kIOMasterPortDefault = ctypes.c_void_p.in_dll(iokit, "kIOMasterPortDefault")
+# kIOMasterPortDefault is no longer exported in BigSur but no biggie, using NULL works just the same
+kIOMasterPortDefault = 0 # WAS: ctypes.c_void_p.in_dll(iokit, "kIOMasterPortDefault")
 kCFAllocatorDefault = ctypes.c_void_p.in_dll(cf, "kCFAllocatorDefault")
 
 kCFStringEncodingMacRoman = 0


### PR DESCRIPTION
Instead of looking up this value, use 0 instead [per IOKit documentation this is the same - https://developer.apple.com/documentation/iokit/kiomasterportdefault]

tested on Big Sur released today.  