### PR TITLE
docs: fix simple typo, paritiy -> parity

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -65,7 +65,7 @@ class PlatformSpecificBase(object):
     
 
 # some systems support an extra flag to enable the two in POSIX unsupported
-# paritiy settings for MARK and SPACE
+# parity settings for MARK and SPACE
 CMSPAR = 0  # default, for unsupported platforms, override below
 
 # try to detect the OS so that a device can be selected...


### PR DESCRIPTION
There is a small typo in serial/serialposix.py.

Should read `parity` rather than `paritiy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md