### PR TITLE
Fix raw spy formating on python3 #467 (tested on both py2 and py3)

### DIFF
--- a/serial/urlhandler/protocol_spy.py
+++ b/serial/urlhandler/protocol_spy.py
@@ -86,14 +86,14 @@ class FormatRaw(object):
         """show received data"""
         if self.color:
             self.output.write(self.rx_color)
-        self.output.write(data)
+        self.output.write(data.decode())
         self.output.flush()
 
     def tx(self, data):
         """show transmitted data"""
         if self.color:
             self.output.write(self.tx_color)
-        self.output.write(data)
+        self.output.write(data.decode())
         self.output.flush()
 
     def control(self, name, value):


### PR DESCRIPTION
Fix raw spy formating on python3 #467 (tested on both py2 and py3)