### PR TITLE
fix interface names on macOS in list_ports.comports

### DIFF
--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -270,6 +270,8 @@ def comports(include_links=False):
         device = get_string_property(service, "IOCalloutDevice")
         if device:
             info = list_ports_common.ListPortInfo(device)
+            # find the serial interface associated with this device
+            serial_interface = GetParentDeviceByType(service, "IOUSBInterface")
             # If the serial port is implemented by IOUSBDevice
             # NOTE IOUSBDevice was deprecated as of 10.11 and finally on Apple Silicon
             # devices has been completely removed.  Thanks to @oskay for this patch.
@@ -288,7 +290,10 @@ def comports(include_links=False):
                 info.manufacturer = get_string_property(usb_device, kUSBVendorString)
                 locationID = get_int_property(usb_device, "locationID", kCFNumberSInt32Type)
                 info.location = location_to_string(locationID)
-                info.interface = search_for_locationID_in_interfaces(serial_interfaces, locationID)
+                info.interface = get_string_property(serial_interface, "USB Interface Name")
+                # fallback to the serial_interfaces search if necessary
+                if info.interface is None:
+                    info.interface = search_for_locationID_in_interfaces(serial_interfaces, locationID)
                 info.apply_usb_info()
             ports.append(info)
     return ports


### PR DESCRIPTION
On macOS Catalina and Big Sur, when connecting a USB device with 2 serial ports, both got associated with the name of the first one. For example running this with a microcontroller exposing two serial port returns the same name for each interface, which it shouldn't:
```py
>>> import serial.tools.list_ports
>>> for port in serial.tools.list_ports.comports():
...     print(port.device,port.interface)
```
```
/dev/cu.Bluetooth-Incoming-Port None
/dev/cu.usbmodem144443121 CircuitPython CDC data
/dev/cu.usbmodem144443123 CircuitPython CDC data
```
That last line should read "CircuitPython CDC2 data"
The interfaces listed by `scan_interfaces()` get associated the same locationID for all ports on the same device, so they all get the name of the first one.

This fix gets the "USB Interface Name" from the current device's nearest `IOUSBInterface` parent before falling back to the scan's list. I don't know enough about IOKit to know if using the scan is still necessary.
```
/dev/cu.Bluetooth-Incoming-Port None
/dev/cu.usbmodem144443123 CircuitPython CDC2 data
/dev/cu.usbmodem144443121 CircuitPython CDC data
```