### PR TITLE
docs: fix typos

### DIFF
--- a/serial/urlhandler/protocol_hwgrep.py
+++ b/serial/urlhandler/protocol_hwgrep.py
@@ -12,7 +12,7 @@
 #
 # where <regexp> is a Python regexp according to the re module
 #
-# violating the normal definition for URLs, the charachter `&` is used to
+# violating the normal definition for URLs, the character `&` is used to
 # separate parameters from the arguments (instead of `?`, but the question mark
 # is heavily used in regexp'es)
 #

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -11,7 +11,7 @@ Part of pySerial (http://pyserial.sf.net)  (C)2001-2011 cliechti@gmx.net
 Intended to be run on different platforms, to ensure portability of
 the code.
 
-Cover some of the aspects of context managment
+Cover some of the aspects of context management
 """
 
 import unittest


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `serial/urlhandler/protocol_hwgrep.py`
- 1 typo in `test/test_context.py`



Bye! :robot: