### PR TITLE
modify serialwin32 write method GetOverlappedResult exception handle

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -318,9 +318,14 @@ class Serial(SerialBase):
 
                 # Wait for the write to complete.
                 #~ win32.WaitForSingleObject(self._overlapped_write.hEvent, win32.INFINITE)
-                win32.GetOverlappedResult(self._port_handle, self._overlapped_write, ctypes.byref(n), True)
-                if win32.GetLastError() == win32.ERROR_OPERATION_ABORTED:
-                    return n.value  # canceled IO is no error
+                result_ok = win32.GetOverlappedResult(
+                    self._port_handle,
+                    self._overlapped_write,
+                    ctypes.byref(n),
+                    True)
+                if not result_ok:
+                    if win32.GetLastError() != win32.ERROR_OPERATION_ABORTED:
+                        raise SerialException("GetOverlappedResult failed ({!r})".format(ctypes.WinError()))
                 if n.value != len(data):
                     raise SerialTimeoutException('Write timeout')
                 return n.value


### PR DESCRIPTION
Modify serialwin32 write method GetOverlappedResult exception handle like read method

https://github.com/pyserial/pyserial/issues/582 In this issue i reported serialwin32.py write method trow out "Write timeout" exception.

I found out [in this commit](https://github.com/pyserial/pyserial/commit/91f63fdd8bb9ad3cfd6348aa8d3fa9eed2a1c60e) and [this commit](https://github.com/pyserial/pyserial/commit/229604e7e7bf04d36c7aa63301e9ba991037d6fe) had already fixed read method GetOverlappedResult func exception handle, but read method forget.

this change may handle follow issues
https://github.com/pyserial/pyserial/issues/460
https://github.com/pyserial/pyserial/issues/113

have a good day
