### PR TITLE
Fix misc. documentation and source comment typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ Same as 1.1 but added missing files.
 
 Version 1.12    18 Feb 2002
 ---------------------------
-Removed unneded constants to fix RH7.x problems.
+Removed unneeded constants to fix RH7.x problems.
 
 
 Version 1.13    09 Apr 2002

--- a/examples/wxTerminal.py
+++ b/examples/wxTerminal.py
@@ -108,7 +108,7 @@ class TerminalSettingsDialog(wx.Dialog):
         self.Bind(wx.EVT_BUTTON, self.OnCancel, id=self.button_cancel.GetId())
 
     def OnOK(self, events):
-        """Update data wil new values and close dialog."""
+        """Update data with new values and close dialog."""
         self.settings.echo = self.checkbox_echo.GetValue()
         self.settings.unprintable = self.checkbox_unprintable.GetValue()
         self.settings.newline = self.radio_box_newline.GetSelection()

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -1,6 +1,6 @@
 #! python
 #
-# This module implements a RFC2217 compatible client. RF2217 descibes a
+# This module implements a RFC2217 compatible client. RF2217 describes a
 # protocol to access serial ports over TCP/IP and allows setting the baud rate,
 # modem control lines etc.
 #

--- a/serial/threaded/__init__.py
+++ b/serial/threaded/__init__.py
@@ -140,7 +140,7 @@ class LineReader(Packetizer):
     def write_line(self, text):
         """
         Write text to the transport. ``text`` is a Unicode string and the encoding
-        is applied before sending ans also the newline is append.
+        is applied before sending and also the newline is append.
         """
         # + is not the best choice but bytes does not support % or .format in py3 and we want a single write call
         self.transport.write(text.encode(self.ENCODING, self.UNICODE_HANDLING) + self.TERMINATOR)

--- a/serial/tools/hexlify_codec.py
+++ b/serial/tools/hexlify_codec.py
@@ -9,7 +9,7 @@
 """\
 Python 'hex' Codec - 2-digit hex with spaces content transfer encoding.
 
-Encode and decode may be a bit missleading at first sight...
+Encode and decode may be a bit misleading at first sight...
 
 The textual representation is a hex dump: e.g. "40 41"
 The "encoded" data of this is the binary form, e.g. b"@A"

--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -277,7 +277,7 @@ def comports(include_links=False):
             if not usb_device:
                 usb_device = GetParentDeviceByType(service, "IOUSBDevice")
             if usb_device:
-                # fetch some useful informations from properties
+                # fetch some useful information from properties
                 info.vid = get_int_property(usb_device, "idVendor", kCFNumberSInt16Type)
                 info.pid = get_int_property(usb_device, "idProduct", kCFNumberSInt16Type)
                 info.serial_number = get_string_property(usb_device, kUSBSerialNumberString)

--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -211,7 +211,7 @@ def get_parent_serial_number(child_devinst, child_vid, child_pid, depth=0, last_
     # store what we found as a fallback for malformed serial values up the chain
     found_serial_number = serial_number
 
-    # Check that the USB serial number only contains alpha-numeric characters. It may be a windows
+    # Check that the USB serial number only contains alphanumeric characters. It may be a windows
     # device ID (ephemeral ID).
     if serial_number and not re.match(r'^\w+$', serial_number):
         serial_number = None
@@ -335,7 +335,7 @@ def iterate_comports():
                     if m.group(5):
                         bInterfaceNumber = int(m.group(5))
 
-                    # Check that the USB serial number only contains alpha-numeric characters. It
+                    # Check that the USB serial number only contains alphanumeric characters. It
                     # may be a windows device ID (ephemeral ID) for composite devices.
                     if m.group(7) and re.match(r'^\w+$', m.group(7)):
                         info.serial_number = m.group(7)

--- a/test/test.py
+++ b/test/test.py
@@ -30,7 +30,7 @@ import serial
 # on which port should the tests be performed:
 PORT = 'loop://'
 
-# indirection via bytearray b/c bytes(range(256)) does something else in Pyhton 2.7
+# indirection via bytearray b/c bytes(range(256)) does something else in Python 2.7
 bytes_0to255 = bytes(bytearray(range(256)))
 
 

--- a/test/test_timeout_class.py
+++ b/test/test_timeout_class.py
@@ -40,7 +40,7 @@ class TestTimeoutClass(unittest.TestCase):
         #~ self.assertFalse(t.expired())
 
     def test_changing_clock(self):
-        """Test recovery from chaning clock"""
+        """Test recovery from changing clock"""
         class T(serialutil.Timeout):
             def TIME(self):
                 return test_time


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,ser,wont`  
First identified from a downstream project that uses the pyserial lib