### PR TITLE
Redirect Minicom's Port Prompt to stderr

### DIFF
--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -372,7 +372,8 @@ def ask_for_port():
         sys.stderr.write('--- {:2}: {:20} {!r}\n'.format(n, port, desc))
         ports.append(port)
     while True:
-        port = raw_input('--- Enter port index or full name: ')
+        sys.stderr.write('--- Enter port index or full name: ')
+        port = raw_input('')
         try:
             index = int(port) - 1
             if not 0 <= index < len(ports):


### PR DESCRIPTION
When asking the user for a serial port to use, the prompt line ends up in stdout, while all other information is written to stderr. If stdout is being redirected (e.g. `pyserial-miniterm | grep expression`, `pyserial-miniterm >> console.log`), the query line ends up in the redirected stream, not on the interactive output.

https://github.com/pyserial/pyserial/blob/9e3b4f364aa50bd62d3044ed0d5221bd42a1c1f4/serial/tools/miniterm.py#L375

This commit fixes that. 