### PR TITLE
Spellcheck

### DIFF
--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -150,7 +150,7 @@ Native ports
         :rtype: bytes
 
         Read *size* bytes from the serial port. If a timeout is set it may
-        return less characters as requested. With no timeout it will block
+        return fewer characters than requested. With no timeout it will block
         until the requested number of bytes is read.
 
         .. versionchanged:: 2.5
@@ -166,7 +166,7 @@ Native ports
 
         Read until an expected sequence is found ('\\n' by default), the size
         is exceeded or until timeout occurs. If a timeout is set it may
-        return less characters as requested. With no timeout it will block
+        return fewer characters than requested. With no timeout it will block
         until the requested number of bytes is read.
 
         .. versionchanged:: 2.5


### PR DESCRIPTION
Really enjoying the changes `pyserial` made through the last decade. Kudos!

Wanted to make a small contribution myself, so I made a little spellcheck change. And while I'm not a native speaker, this way it sounds clearer to me. "as expected" sounds to me like "similar or equal to what you should expect", but here it means that you might expect 800 bytes and just receive 300.