### PR TITLE
Fix duplicate comports listed with list_ports(include_links=True)

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -89,15 +89,16 @@ class SysFS(list_ports_common.ListPortInfo):
 
 
 def comports(include_links=False):
-    devices = glob.glob('/dev/ttyS*')           # built-in serial ports
-    devices.extend(glob.glob('/dev/ttyUSB*'))   # usb-serial with own driver
-    devices.extend(glob.glob('/dev/ttyXRUSB*')) # xr-usb-serial port exar (DELL Edge 3001)
-    devices.extend(glob.glob('/dev/ttyACM*'))   # usb-serial with CDC-ACM profile
-    devices.extend(glob.glob('/dev/ttyAMA*'))   # ARM internal port (raspi)
-    devices.extend(glob.glob('/dev/rfcomm*'))   # BT serial devices
-    devices.extend(glob.glob('/dev/ttyAP*'))    # Advantech multi-port serial controllers
+    devices = set()
+    devices.update(glob.glob('/dev/ttyS*'))     # built-in serial ports
+    devices.update(glob.glob('/dev/ttyUSB*'))   # usb-serial with own driver
+    devices.update(glob.glob('/dev/ttyXRUSB*')) # xr-usb-serial port exar (DELL Edge 3001)
+    devices.update(glob.glob('/dev/ttyACM*'))   # usb-serial with CDC-ACM profile
+    devices.update(glob.glob('/dev/ttyAMA*'))   # ARM internal port (raspi)
+    devices.update(glob.glob('/dev/rfcomm*'))   # BT serial devices
+    devices.update(glob.glob('/dev/ttyAP*'))    # Advantech multi-port serial controllers
     if include_links:
-        devices.extend(list_ports_common.list_links(devices))
+        devices.update(list_ports_common.list_links(devices))
     return [info
             for info in [SysFS(d) for d in devices]
             if info.subsystem != "platform"]    # hide non-present internal serial ports

--- a/serial/tools/list_ports_posix.py
+++ b/serial/tools/list_ports_posix.py
@@ -37,63 +37,63 @@ elif plat == 'cygwin':       # cygwin/win32
     # (such as 'open' call, explicit 'ls'), but 'glob.glob'
     # and bare 'ls' do not; so use /dev/ttyS* instead
     def comports(include_links=False):
-        devices = glob.glob('/dev/ttyS*')
+        devices = set(glob.glob('/dev/ttyS*'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:7] == 'openbsd':    # OpenBSD
     def comports(include_links=False):
-        devices = glob.glob('/dev/cua*')
+        devices = set(glob.glob('/dev/cua*'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:3] == 'bsd' or plat[:7] == 'freebsd':
     def comports(include_links=False):
-        devices = glob.glob('/dev/cua*[!.init][!.lock]')
+        devices = set(glob.glob('/dev/cua*[!.init][!.lock]'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:6] == 'netbsd':   # NetBSD
     def comports(include_links=False):
         """scan for available ports. return a list of device names."""
-        devices = glob.glob('/dev/dty*')
+        devices = set(glob.glob('/dev/dty*'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:4] == 'irix':     # IRIX
     def comports(include_links=False):
         """scan for available ports. return a list of device names."""
-        devices = glob.glob('/dev/ttyf*')
+        devices = set(glob.glob('/dev/ttyf*'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:2] == 'hp':       # HP-UX (not tested)
     def comports(include_links=False):
         """scan for available ports. return a list of device names."""
-        devices = glob.glob('/dev/tty*p0')
+        devices = set(glob.glob('/dev/tty*p0'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:5] == 'sunos':    # Solaris/SunOS
     def comports(include_links=False):
         """scan for available ports. return a list of device names."""
-        devices = glob.glob('/dev/tty*c')
+        devices = set(glob.glob('/dev/tty*c'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 elif plat[:3] == 'aix':      # AIX
     def comports(include_links=False):
         """scan for available ports. return a list of device names."""
-        devices = glob.glob('/dev/tty*')
+        devices = set(glob.glob('/dev/tty*'))
         if include_links:
-            devices.extend(list_ports_common.list_links(devices))
+            devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
 else:


### PR DESCRIPTION
In case there are any symlinks which name matches any of the previously
checked globs then list_ports(include_links=True) will report them twice.
For example if there's a symlink named /dev/ttyUSB_mylink then it would
appear twice.

The problem is fixed by storing the found paths in a set instead of a list.
Documentation at https://pythonhosted.org/pyserial/tools.html#module-serial.tools.list_ports
already states that "Items are returned in no particular order" so there's
no need to do extra sorting before returning the results.

The changes have been tested on Ubuntu (using list_ports_linux.py).