### PR TITLE
Fix UnboundLocalError on timeout

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -825,6 +825,7 @@ class PosixPollSerial(Serial):
         poll.register(self.pipe_abort_read_r, select.POLLIN | select.POLLERR | select.POLLHUP | select.POLLNVAL)
         if size > 0:
             while len(read) < size:
+                fd = None #In case poll.poll() returns nothing
                 # print "\tread(): size",size, "have", len(read)    #debug
                 # wait until device becomes ready to read (or something fails)
                 for fd, event in poll.poll(None if timeout.is_infinite else (timeout.time_left() * 1000)):


### PR DESCRIPTION
On timeout, fd is no longer unbound for the check on line 838. Causes an os.read() still to be called, but it seems to be harmless on my machine. Addresses issue #617.