### PR TITLE
do no filter out platform devices anymore

### DIFF
--- a/serial/tools/list_ports_linux.py
+++ b/serial/tools/list_ports_linux.py
@@ -98,9 +98,10 @@ def comports(include_links=False):
     devices.extend(glob.glob('/dev/ttyAP*'))    # Advantech multi-port serial controllers
     if include_links:
         devices.extend(list_ports_common.list_links(devices))
+
     return [info
             for info in [SysFS(d) for d in devices]
-            if info.subsystem != "platform"]    # hide non-present internal serial ports
+            ]
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # test


### PR DESCRIPTION
serial devices considered as 'platform' were filtered out of
enumeration, for some obscure reason, making the library
unusable on most embedded systems.

Signed-off-by: Thierry Bultel <thierry.bultel@linatsea.fr>