### PR TITLE
Close opened file handler on closing the serial port

### DIFF
--- a/serial/urlhandler/protocol_spy.py
+++ b/serial/urlhandler/protocol_spy.py
@@ -330,6 +330,11 @@ class Serial(serial.Serial):
         self.formatter.control('CD', 'active' if level else 'inactive')
         return level
 
+    def close(self):
+        if self.formatter.output.name != 'stderr':
+            self.formatter.output.close()
+        super(Serial, self).close()
+
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 if __name__ == '__main__':
     ser = Serial(None)


### PR DESCRIPTION
When using the  spy://___URI___?file=__SOME_FILE___&raw format for serial port the __SOME_FILE___ is opened and its file handler is not closed when the serial port is closed. This patch fixes this. By default the opened stream is 'stderr' which cannot be closed, so check for its existence is made.