### PR TITLE
Fixed socket:// on Windows because of missing out_waiting property

### DIFF
--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -142,6 +142,15 @@ class Serial(SerialBase):
         lr, lw, lx = select.select([self._socket], [], [], 0)
         return len(lr)
 
+    @property
+    def out_waiting(self):
+        """Return 1 if port is able to send data."""
+        if not self.is_open:
+            raise PortNotOpenError()
+        # Poll the socket to see if it is ready for writing.
+        lr, lw, lx = select.select([], [self._socket], [], 0)
+        return len(lw)
+
     # select based implementation, similar to posix, but only using socket API
     # to be portable, additionally handle socket timeout which is used to
     # emulate write timeouts


### PR DESCRIPTION
This PR fixes the following exception on Windows:

```
Traceback (most recent call last):
  File "C:\Development\Python\lib\asyncio\events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "C:\Development\HomeAssistant\config\deps\Python39\site-packages\serial_asyncio\__init__.py", line 307, in _poll_write
    if self.serial.out_waiting < self._max_out_waiting:
AttributeError: 'Serial' object has no attribute 'out_waiting'
```
Also described here: https://github.com/pyserial/pyserial-asyncio/issues/74