### PR TITLE
Fix a couple of documentation links

### DIFF
--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -486,11 +486,11 @@ Native ports
 
     .. method:: readline(size=-1)
 
-        Provided via :meth:`io.IOBase.readline` See also ref:`shortintro_readline`.
+        Provided via :meth:`io.IOBase.readline` See also :ref:`shortintro_readline`.
 
     .. method:: readlines(hint=-1)
 
-        Provided via :meth:`io.IOBase.readlines`. See also ref:`shortintro_readline`.
+        Provided via :meth:`io.IOBase.readlines`. See also :ref:`shortintro_readline`.
 
     .. method:: writelines(lines)
 


### PR DESCRIPTION
Some minor ref correction (`ref:` -> `:ref:`)