### PR TITLE
Add example about listing ports via python (not via cmd)

### DIFF
--- a/documentation/examples.rst
+++ b/documentation/examples.rst
@@ -5,6 +5,18 @@
 ==========
 
 
+List all available serial ports
+===============================
+
+This can be done by importing ``comports`` from ``serial.tools.list_ports``:
+
+::
+
+    from serial.tools.list_ports import comports
+    for port in comports():
+        print(port)
+
+
 Miniterm
 ========
 Miniterm is now available as module instead of example.

--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -108,6 +108,9 @@ Listing ports
 is also possible to add a regexp as first argument and the list will only
 include entries that matched.
 
+Also see `this example <https://pythonhosted.org/pyserial/examples.html#list-all-available-serial-ports>`_
+which shows how to list all ports from python instead of the commandline.
+
 .. note::
 
     The enumeration may not work on all operating systems. It may be

--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -9,7 +9,10 @@ serial.tools.list_ports
 .. module:: serial.tools.list_ports
 
 This module can be executed to get a list of ports (``python -m
-serial.tools.list_ports``). It also contains the following functions.
+serial.tools.list_ports``). Also see `this example <https://pythonhosted.org/pyserial/examples.html#list-all-available-serial-ports>`_
+which shows how to list all ports from python instead of the commandline.
+It also contains the following functions.
+
 
 
 .. function:: comports(include_links=False)


### PR DESCRIPTION
This pull request resolves issue https://github.com/pyserial/pyserial/issues/655. It is only a documentation change, and adds one example describing how to use pySerial to list all available ports via python, and then adds references to this example in appropriate places where the alternative `python -m serial.tools.list_ports` is listed.

Hope this is useful! let me know if you'd like any changes.