### PR TITLE
support ironpython new version

### DIFF
--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -20,7 +20,7 @@ __version__ = '3.5'
 VERSION = __version__
 
 # pylint: disable=wrong-import-position
-if sys.platform == 'cli':
+if sys.platform == 'cli' or sys.implementation.name == "ironpython":
     from serial.serialcli import Serial
 else:
     import os

--- a/serial/serialcli.py
+++ b/serial/serialcli.py
@@ -19,7 +19,8 @@ sab = System.Array[System.Byte]
 
 
 def as_byte_array(string):
-    return sab([ord(x) for x in string])  # XXX will require adaption when run with a 3.x compatible IronPython
+    
+    return sab([ord(x) for x in string]) if isinstance(string, str) else sab([x for x in string])
 
 
 class Serial(SerialBase):

--- a/serial/serialcli.py
+++ b/serial/serialcli.py
@@ -19,7 +19,6 @@ sab = System.Array[System.Byte]
 
 
 def as_byte_array(string):
-    
     return sab([ord(x) for x in string]) if isinstance(string, str) else sab([x for x in string])
 
 


### PR DESCRIPTION
in the new versions of ironpython (3.4), some changes were needed

[platform detection method](https://github.com/IronLanguages/ironpython3/blob/master/Documentation/upgrading-from-ipy2.md#checking-for-ironpython)

[getting byte array from result](https://github.com/pyserial/pyserial/blob/0e7634747568547b8a7f9fd0c48ed74f16af4b23/serial/serialcli.py#L22)