### PR TITLE
Allow for longer location Strings.

### DIFF
--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -343,7 +343,7 @@ def iterate_comports():
                         info.serial_number = get_parent_serial_number(devinfo.DevInst, info.vid, info.pid)
 
                 # calculate a location string
-                loc_path_str = ctypes.create_unicode_buffer(250)
+                loc_path_str = ctypes.create_unicode_buffer(500)
                 if SetupDiGetDeviceRegistryProperty(
                         g_hdi,
                         ctypes.byref(devinfo),


### PR DESCRIPTION
When using a Composite device connected to a USB-Hub (e.g. HP-Docking Station) the location string is longer than the previous buffer of 250. This then fails to extract the correct string. Doubling the buffer size got it to work as expected!