### PR TITLE
Add detection for Haiku's serial ports

### DIFF
--- a/serial/tools/list_ports_posix.py
+++ b/serial/tools/list_ports_posix.py
@@ -96,6 +96,14 @@ elif plat[:3] == 'aix':      # AIX
             devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
+elif plat[:5] == 'haiku':    # Haiku
+    def comports(include_links=False):
+        """scan for available ports. return a list of device names."""
+        devices = set(glob.glob('/dev/ports/*'))
+        if include_links:
+            devices.update(list_ports_common.list_links(devices))
+        return [list_ports_common.ListPortInfo(d) for d in devices]
+
 else:
     # platform detection has failed...
     import serial


### PR DESCRIPTION
Now that PySerial works OK (without patches. relying on serialposix.py) on the nightly versions of Haiku (see https://haiku-os.org), make sure its ports gets detected properly.