### PR TITLE
workaround win32 crash (or error) on SetCommState

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -26,6 +26,8 @@ class Serial(SerialBase):
     BAUDRATES = (50, 75, 110, 134, 150, 200, 300, 600, 1200, 1800, 2400, 4800,
                  9600, 19200, 38400, 57600, 115200)
 
+    BUF_SIZE = 4096
+
     def __init__(self, *args, **kwargs):
         self._port_handle = None
         self._overlapped_read = None
@@ -71,7 +73,7 @@ class Serial(SerialBase):
             self._overlapped_write.hEvent = win32.CreateEvent(None, 0, 0, None)
 
             # Setup a 4k buffer
-            win32.SetupComm(self._port_handle, 4096, 4096)
+            win32.SetupComm(self._port_handle, self.BUF_SIZE, self.BUF_SIZE)
 
             # Save original timeout values:
             self._orgTimeouts = win32.COMMTIMEOUTS()
@@ -132,6 +134,8 @@ class Serial(SerialBase):
         comDCB = win32.DCB()
         win32.GetCommState(self._port_handle, ctypes.byref(comDCB))
         comDCB.BaudRate = self._baudrate
+        comDCB.XonLim = self.BUF_SIZE // 4
+        comDCB.XoffLim = comDCB.XonLim
 
         if self._bytesize == serial.FIVEBITS:
             comDCB.ByteSize = 5


### PR DESCRIPTION
I believe there is a bug (a.k.a the crash "OSError: exception: stack overflow") in `SetCommState`. 

## Steps to trigger the crash

1. Use some other tools to open a COM port where
    * a large buffer size (e.g. 102400) is configured in `SetupComm`,
    * set `XonLim` and `XoffLim` to (102400 / 4) in `SetCommState`
2. Close the port;
3. Use _pyserial_ to open the port.

## Test Environment

* JLink CDC COM;
* Latest Windows 10/11.

## Expected Behavior

Window may return an error code but not crash if it finds something strange.

## Workaround

It seems unrealistic to wait MS to fix this. So here comes the workaround, which might also resolve #258 and #362:

Set `XonLim` and `XoffLim` according to buffer size configured in `SetupComm`.