### PR TITLE
Allow container to be passed into read_until function

### DIFF
--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -654,19 +654,27 @@ class SerialBase(io.RawIOBase):
     def read_until(self, expected=LF, size=None):
         """\
         Read until an expected sequence is found (line feed by default), the size
-        is exceeded or until timeout occurs.
+        is exceeded or until timeout occurs. An iterable object can also be supplied
+        to the expected arg to allow for multiple checks.
         """
-        lenterm = len(expected)
         line = bytearray()
         timeout = Timeout(self._timeout)
+
+        # Preserve for backwards compatiblity
+        if isinstance(expected, bytes):
+            expected = (expected,)
+
+        delimiters = {i:len(i) for i in expected}
+
         while True:
             c = self.read(1)
             if c:
                 line += c
-                if line[-lenterm:] == expected:
-                    break
-                if size is not None and len(line) >= size:
-                    break
+                for delimeter, lenterm in delimiters.items():
+                    if line[-lenterm:] == delimeter:
+                        return bytes(line)
+                    if size is not None and len(line) >= size:
+                        return bytes(line)
             else:
                 break
             if timeout.expired():

--- a/test/test_read_until.py
+++ b/test/test_read_until.py
@@ -1,0 +1,34 @@
+import unittest
+import serial
+
+# ~  print serial.VERSION
+
+# on which port should the tests be performed:
+PORT = "loop://"
+
+
+class Test_Read_Until(unittest.TestCase):
+    """Test read_until function"""
+
+    def setUp(self):
+        self.ser = serial.serial_for_url(PORT, timeout=1)
+        self.msg = serial.to_bytes([0x46, 0x4F, 0x4F])
+
+    def tearDown(self):
+        self.ser.close()
+
+    def test_read_until_using_single_delimiter(self):
+        delimiter = b"\r"
+        msg = self.msg + delimiter
+        self.ser.write(msg)
+        self.assertEqual(self.ser.read_until(delimiter), msg)
+
+    def test_read_until_using_multiple_delimiters(self):
+        delimiters = (b"\r", b"\a")
+        msg = self.msg + delimiters[0] + delimiters[-1]
+
+        self.ser.write(msg)
+        self.assertEqual(self.ser.read_until(delimiters), self.msg + delimiters[0])
+
+        self.ser.write(msg[::-1])
+        self.assertEqual(self.ser.read_until(delimiters), delimiters[-1])


### PR DESCRIPTION
Currently `read_until()` argument `expected` only accepts a single byte object. This is used as the delimiter for signaling the function to stop reading and return. 

This PR preserves that functionality but also allows an iterable container to be passed into `expected`. This allows the use of multiple delimiters to act on.

Also added are unittests for both a single and multiple delimiters. 