### PR TITLE
Include /dev/serial/by-id/* devices in links

### DIFF
--- a/serial/tools/list_ports_common.py
+++ b/serial/tools/list_ports_common.py
@@ -109,7 +109,7 @@ def list_links(devices):
     listed in devices.
     """
     links = []
-    for device in glob.glob('/dev/*'):
+    for device in glob.glob('/dev/*') + glob.glob('/dev/serial/by-id/*'):
         if os.path.islink(device) and os.path.realpath(device) in devices:
             links.append(device)
     return links


### PR DESCRIPTION
When providing a user with an option to select the serial port in linux, the links under `/dev/serial/by-id/*` are not shown.

Identifiers such as `/dev/ttyUSB1` etc are not reliable through reboots or reconfiguration, see #699.

This PR adds an the additional search path `/dev/serial/by-id/*`, so that links to ports can be shown to the user by their serial number identifier as well as the `ttyUSBx` style name.

I have run the tests via `test/run_all_tests.py`, and all passed.