### PR TITLE
win32: Get the string description of the usb serial port via DeviceIoControl.

### DIFF
--- a/serial/win32.py
+++ b/serial/win32.py
@@ -189,6 +189,10 @@ CancelIoEx = _stdcall_libraries['kernel32'].CancelIoEx
 CancelIoEx.restype = BOOL
 CancelIoEx.argtypes = [HANDLE, LPOVERLAPPED]
 
+DeviceIoControl = _stdcall_libraries['kernel32'].DeviceIoControl
+DeviceIoControl.restype = BOOL
+DeviceIoControl.argtypes = [HANDLE, DWORD, LPVOID, DWORD, LPVOID, DWORD, LPDWORD, LPOVERLAPPED]
+
 ONESTOPBIT = 0  # Variable c_int
 TWOSTOPBITS = 2  # Variable c_int
 ONE5STOPBITS = 1


### PR DESCRIPTION
This pull request helps to get the serial number, product string and manufacturer string of the usb serial port correctly on windows.

https://lihashgnis.blogspot.com/2018/07/getting-descriptors-from-usb-device.html?m=1
https://stackoverflow.com/questions/28007468/how-do-i-obtain-usb-device-descriptor-given-a-device-path
https://stackoverflow.com/questions/50701189/how-to-get-usb-device-descriptor-by-doing-deviceiocontrol-directly-on-the-devi

Because the com port description provided by the windows registry is not the usb description we often need, I refer to the above to get the device description of the usb serial port via DeviceIoControl.

#637 
