### PR TITLE
Set  RTS and DTR lines at the same time when they are the same value 

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -339,10 +339,10 @@ class Serial(SerialBase, PlatformSpecific):
             self._reconfigure_port(force_update=True)
 
             try:
-                if not self._dsrdtr:
-                    self._update_dtr_state()
                 if not self._rtscts:
                     self._update_rts_state()
+                if not self._dsrdtr:
+                    self._update_dtr_state()
             except IOError as e:
                 # ignore Invalid argument and Inappropriate ioctl
                 if e.errno not in (errno.EINVAL, errno.ENOTTY):


### PR DESCRIPTION
Fixes #731 

When both the DTR and RST lines are bien get to the same value, this PR will cause them to be set at the same time instead of setting one of them followed by the other. 

