### PR TITLE
treewide: fix remaining uses of threading camel case methods

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -463,7 +463,7 @@ class Serial(SerialBase):
         self.is_open = True
         self._thread = threading.Thread(target=self._telnet_read_loop)
         self._thread.daemon = True
-        self._thread.setName('pySerial RFC 2217 reader thread for {}'.format(self._port))
+        self._thread.name = 'pySerial RFC 2217 reader thread for {}'.format(self._port)
         self._thread.start()
 
         try:    # must clean-up if open fails

--- a/serial/urlhandler/protocol_cp2110.py
+++ b/serial/urlhandler/protocol_cp2110.py
@@ -100,7 +100,7 @@ class Serial(SerialBase):
             self.is_open = True
             self._thread = threading.Thread(target=self._hid_read_loop)
             self._thread.daemon = True
-            self._thread.setName('pySerial CP2110 reader thread for {}'.format(self._port))
+            self._thread.name = 'pySerial CP2110 reader thread for {}'.format(self._port)
             self._thread.start()
 
     def from_url(self, url):


### PR DESCRIPTION
The threading camel case methods were deprecated in https://github.com/python/cpython/pull/25174. PR #643 fixed a bunch of these warnings, but missed a few.

Fix the remaining `setName()` DeprecationWarnings by using the appropriate `name` attribute instead.