### PR TITLE
Update shortintro.rst

### DIFF
--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -91,10 +91,10 @@ mode, it is advised to use io.TextIOWrapper_::
         ser = serial.serial_for_url('loop://', timeout=1)
         sio = io.TextIOWrapper(io.BufferedRWPair(ser, ser))
 
-        sio.write(unicode("hello\n"))
+        sio.write("hello\n")
         sio.flush() # it is buffering. required to get the data out *now*
         hello = sio.readline()
-        print(hello == unicode("hello\n"))
+        print(hello == "hello\n")
 
 
 .. _io.TextIOWrapper: http://docs.python.org/library/io.html#io.TextIOWrapper


### PR DESCRIPTION
Suggesting changes to work on python3 
The existing code works on python2 but not python3 . Please notice

The character encoding can be defined in the TextIOWrapper instead otherwise if not given in TextIOWrapper it will be None 
The code sample can be split into python2 and python3 as  an additional note. 
