### PR TITLE
Replace deprecated unittest.findTestCases function

### DIFF
--- a/test/run_all_tests.py
+++ b/test/run_all_tests.py
@@ -37,7 +37,8 @@ for modulename in [
         print("skipping {}".format(modulename))
     else:
         module.PORT = PORT
-        testsuite = unittest.findTestCases(module)
+        loader = unittest.TestLoader()
+        testsuite = loader.loadTestsFromModule(module)
         print("found {} tests in {!r}".format(testsuite.countTestCases(), modulename))
         mainsuite.addTest(testsuite)
 


### PR DESCRIPTION
The unittest.findTestCases function was deprecated in Python 3.11 and later removed in Python 3.13. The TestLoader methods should be used instead [1].

[1] https://docs.python.org/3.13/whatsnew/3.13.html#unittest

Fixes: #754