### PR TITLE
Fix for Interface always None on Windows

### DIFF
--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -364,6 +364,7 @@ def iterate_comports():
                                 location.append('-')
                             location.append(g.group(2))
                     if bInterfaceNumber is not None:
+                        info.interface = bInterfaceNumber
                         location.append(':{}.{}'.format(
                             'x',  # XXX how to determine correct bConfigurationValue?
                             bInterfaceNumber))


### PR DESCRIPTION
When listing comports on Windows, the interface is always set to None. This is because in list_ports_windows.py the bInterfaceNumber is correctly determined and set locally with the variable bInterfaceNumber.  But it is never set to the object, so when serial.tools.list_ports.comports() is run, interface is always None. 

This one-line addition fixes that.