### PR TITLE
shortintro.rst:EOL remove unicode()

### DIFF
--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -91,10 +91,10 @@ mode, it is advised to use io.TextIOWrapper_::
         ser = serial.serial_for_url('loop://', timeout=1)
         sio = io.TextIOWrapper(io.BufferedRWPair(ser, ser))
 
-        sio.write(unicode("hello\n"))
+        sio.write("hello\n") # note that type is 'str' not 'bytes'
         sio.flush() # it is buffering. required to get the data out *now*
         hello = sio.readline()
-        print(hello == unicode("hello\n"))
+        print(hello == "hello\n")
 
 
 .. _io.TextIOWrapper: http://docs.python.org/library/io.html#io.TextIOWrapper


### PR DESCRIPTION
The function was removed in Python3.
Now the str type can contain unicode.
