### PR TITLE
rfc2217: do not set logger = None inside open()

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -404,7 +404,6 @@ class Serial(SerialBase):
         Open port with current settings. This may throw a SerialException
         if the port cannot be opened.
         """
-        self.logger = None
         self._ignore_set_control_answer = False
         self._poll_modem_state = False
         self._network_timeout = 3


### PR DESCRIPTION
The logger field is already initialized inside __init__ so no need to do it again.

It is possible for the user to initialize logger after __init__ and before open(), if that happens then we should log all negotiation messages. Right now they are always lost.