### PR TITLE
Allow to distinguish between serial interfaces on macos by filling more information.

### DIFF
--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -241,9 +241,13 @@ def scan_interfaces():
     for service in GetIOServicesByType('IOSerialBSDClient'):
         device = get_string_property(service, "IOCalloutDevice")
         if device:
-            usb_device = GetParentDeviceByType(service, "IOUSBInterface")
+            usb_device = GetParentDeviceByType(service, "IOUSBHostInterface")
+            if not usb_device:
+                # IOUSBInterface is deprecated
+                usb_device = GetParentDeviceByType(service, "IOUSBInterface")
             if usb_device:
-                name = get_string_property(usb_device, "USB Interface Name") or None
+                name = get_string_property(usb_device, "USB Product Name") \
+                    or get_string_property(usb_device, "USB Interface Name") or None
                 locationID = get_int_property(usb_device, "locationID", kCFNumberSInt32Type) or ''
                 i = SuitableSerialInterface()
                 i.id = locationID

--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -274,11 +274,19 @@ def comports(include_links=False):
         device = get_string_property(service, "IOCalloutDevice")
         if device:
             info = list_ports_common.ListPortInfo(device)
-            # If the serial port is implemented by IOUSBDevice
-            # NOTE IOUSBDevice was deprecated as of 10.11 and finally on Apple Silicon
-            # devices has been completely removed.  Thanks to @oskay for this patch.
+
+            interface = None
+
+            # Try IOUserSerial to get lowest possible and most detailed name
+            # of our serial interface.
+            usb_device = GetParentDeviceByType(service, "IOUserSerial")
+            if usb_device:
+                interface = get_string_property(usb_device, "USB Product Name")
+
+            # Search for device implementing our serial interfaces.
             usb_device = GetParentDeviceByType(service, "IOUSBHostDevice")
             if not usb_device:
+                # IOUSBDevice is deprecated
                 usb_device = GetParentDeviceByType(service, "IOUSBDevice")
             if usb_device:
                 # fetch some useful information from properties
@@ -292,7 +300,7 @@ def comports(include_links=False):
                 info.manufacturer = get_string_property(usb_device, kUSBVendorString)
                 locationID = get_int_property(usb_device, "locationID", kCFNumberSInt32Type)
                 info.location = location_to_string(locationID)
-                info.interface = search_for_locationID_in_interfaces(serial_interfaces, locationID)
+                info.interface = interface or search_for_locationID_in_interfaces(serial_interfaces, locationID)
                 info.apply_usb_info()
             ports.append(info)
     return ports


### PR DESCRIPTION
Enhance macos (tested on apple silicon) experience where we have multiple serial interfaces implemented by single physical device.

Currently there is no way to distinguish between these two. More in commit logs.

ioreg -r -c IOUSBHostDevice -l (shorted) output attached to show that tree looks for this device.

````

-o AppleUSB20HubPort@01112110  <class AppleUSB20HubPort, id 0x10000e7c2, registered, matched, active, busy 0 (4884 ms), retain 16>
 | }
 | 
 +-o CP2105 Dual USB to UART Bridge Controller@01112110  <class IOUSBHostDevice, id 0x10000e7cb, registered, matched, active, busy 0 (4880 ms), retain 41>
   | {
   |   "idProduct" = 60016
   |   "iManufacturer" = 1
   |   "iProduct" = 2
   |   "iSerialNumber" = 5
   |   "UsbDeviceSignature" = <c41070ea00013031383136463043000000ff0000>
   |   "USB Product Name" = "CP2105 Dual USB to UART Bridge Controller"
   |   "locationID" = 17899792
   |   "kUSBSerialNumberString" = "XXX"
   |   "USB Vendor Name" = "Silicon Labs"
   |   "idVendor" = 4292
   |   "kUSBProductString" = "CP2105 Dual USB to UART Bridge Controller"
   |   "USB Serial Number" = "XXX"
   |   "kUSBVendorString" = "Silicon Labs"
   |   [...]
   | }
   | 
   +-o Enhanced Com Port@0  <class IOUSBHostInterface, id 0x10000e7d3, registered, matched, active, busy 0 (4857 ms), retain 10>
   | | {
   | |   "iInterface" = 3
   | |   "idProduct" = 60016
   | |   "USB Product Name" = "CP2105 Dual USB to UART Bridge Controller"
   | |   "locationID" = 17899792
   | |   "kUSBString" = "Enhanced Com Port"
   | |   "bInterfaceNumber" = 0
   | |   "USB Vendor Name" = "Silicon Labs"
   | |   "idVendor" = 4292
   | |   "bNumEndpoints" = 2
   | |   "USB Serial Number" = "XXX"
   | |   [...]
   | | }
   | | 
   | +-o com_silabs_cp210x  <class IOUserSerial, id 0x10000e7d8, registered, matched, active, busy 0 (4774 ms), retain 11>
   |   | {
   |   |   "IOClass" = "IOUserSerial"
   |   |   "IOUserClass" = "com_silabs_cp210x"
   |   |   "IOUserServerName" = "com.silab.driverkit"
   |   |   "idProduct" = 60016
   |   |   "USB Product Name" = "CP210x USB to UART Bridge Controller (Enhanced Port)"
   |   |   "bInterfaceNumber" = 0
   |   |   "idVendor" = 4292
   |   |   [...]
   |   | }
   |   | 
   |   +-o IOSerialBSDClient  <class IOSerialBSDClient, id 0x10000e7de, registered, matched, active, busy 0 (3 ms), retain 5>
   |       {
   |         "IOClass" = "IOSerialBSDClient"
   |         "CFBundleIdentifier" = "com.apple.iokit.IOSerialFamily"
   |         "IOProviderClass" = "IOSerialStreamSync"
   |         "IOTTYBaseName" = "SLAB_USBtoUART"
   |         "IOSerialBSDClientType" = "IOSerialStream"
   |         "IOProbeScore" = 1000
   |         "IOResourceMatch" = "IOBSD"
   |         "IOMatchedAtBoot" = Yes
   |         "IOMatchCategory" = "IODefaultMatchCategory"
   |         "IOTTYDevice" = "SLAB_USBtoUART4"
   |         "IOCalloutDevice" = "/dev/cu.SLAB_USBtoUART4"
   |         "IODialinDevice" = "/dev/tty.SLAB_USBtoUART4"
   |         "IOPersonalityPublisher" = "com.apple.iokit.IOSerialFamily"
   |         "CFBundleIdentifierKernel" = "com.apple.iokit.IOSerialFamily"
   |         "IOTTYSuffix" = "4"
   |       }
   |       
   +-o Standard Com Port@1  <class IOUSBHostInterface, id 0x10000e7d6, registered, matched, active, busy 0 (60 ms), retain 10>
     | {
     |   "iInterface" = 4
     |   "idProduct" = 60016
     |   "USB Product Name" = "CP2105 Dual USB to UART Bridge Controller"
     |   "locationID" = 17899792
     |   "kUSBString" = "Standard Com Port"
     |   "bInterfaceNumber" = 1
     |   "USB Vendor Name" = "Silicon Labs"
     |   "idVendor" = 4292
     |   "bNumEndpoints" = 2
     |   "USB Serial Number" = "XXX"
     |   [...]
     | }
     | 
     +-o com_silabs_cp210x  <class IOUserSerial, id 0x10000e7d7, registered, matched, active, busy 0 (2 ms), retain 11>
       | {
       |   "IOClass" = "IOUserSerial"
       |   "IOUserClass" = "com_silabs_cp210x"
       |   "IOUserServerName" = "com.silab.driverkit"
       |   "idProduct" = 60016
       |   "USB Product Name" = "CP210x USB to UART Bridge Controller (Standard Port)"
       |   "bInterfaceNumber" = 1
       |   "idVendor" = 4292
       }   [...]
       | }
       | 
       +-o IOSerialBSDClient  <class IOSerialBSDClient, id 0x10000e7db, registered, matched, active, busy 0 (1 ms), retain 5>
           {
             "IOClass" = "IOSerialBSDClient"
             "CFBundleIdentifier" = "com.apple.iokit.IOSerialFamily"
             "IOProviderClass" = "IOSerialStreamSync"
             "IOTTYBaseName" = "SLAB_USBtoUART"
             "IOSerialBSDClientType" = "IOSerialStream"
             "IOProbeScore" = 1000
             "IOResourceMatch" = "IOBSD"
             "IOMatchedAtBoot" = Yes
             "IOMatchCategory" = "IODefaultMatchCategory"
             "IOTTYDevice" = "SLAB_USBtoUART"
             "IOCalloutDevice" = "/dev/cu.SLAB_USBtoUART"
             "IODialinDevice" = "/dev/tty.SLAB_USBtoUART"
             "IOPersonalityPublisher" = "com.apple.iokit.IOSerialFamily"
             "CFBundleIdentifierKernel" = "com.apple.iokit.IOSerialFamily"
             "IOTTYSuffix" = ""
           }

````