### PR TITLE
Fix wrong implementation of `in_waiting` in `protocol_socket.py`

### DIFF
--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -184,7 +184,7 @@ class Serial(SerialBase):
                 # there is nothing to read.
                 if not ready:
                     break   # timeout
-                buf = self._socket.recv(size - len(read))
+                buf = self._socket.recv(min(size - len(read), self.in_waiting))
                 # read should always return some data as select reported it was
                 # ready to read when we get to this point, unless it is EOF
                 if not buf:


### PR DESCRIPTION
fix #759 

As the description in #759, the function is wrong. It returns the number of ready sockets. In the context, it will returen 0 or 1. Also the `read()` , the parameter of `recv()` should be available data or left buf size. 