### PR TITLE
Add --only-one (-1) option to serial.tools.list_ports CLI

### DIFF
--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -125,20 +125,20 @@ serial.tools.list_ports``). It also contains the following functions.
 
 Help for ``python -m serial.tools.list_ports``::
 
-    usage: list_ports.py [-h] [-v] [-q] [-n N] [-s] [regexp]
+    usage: list_ports.py [-h] [-v] [-q] [-1] [-n N] [-s] [regexp]
 
     Serial port enumeration
 
     positional arguments:
       regexp               only show ports that match this regex
 
-    optional arguments:
+    options:
       -h, --help           show this help message and exit
       -v, --verbose        show more messages
       -q, --quiet          suppress all messages
+      -1, --only-one       require exactly one matching entry, otherwise error
       -n N                 only output the N-th entry
       -s, --include-links  include entries that are symlinks to real devices
-
 
 Examples:
 


### PR DESCRIPTION
If this option is set, and there isn't exactly 1 ports matching any supplied filters, `list_ports` will print an informative error and exit with an error code. Otherwise it will print the port as usual.

This is for the extremely common use case of using the tool in a script to find the expected device to perform some operation with:
```
blah/blah/my_tool --port=$(pyserial-ports -q -1 2E43:0226) ...
```
The `-n 1` flag is often used this way, but it's not ideal because if there is more than one matching device one will be arbitrarily chosen (an error is almost certainly preferable), and more importantly if there are no matching devices output will be empty, yielding confusing errors down the line. For this purpose `--only-one` (aka `-1`) as introduced here is much more robust.

Note, I was unable to figure out how to run `pylint` on this code. If you point me to instructions I'll make sure that's clean. Tests do pass, though tests never exercised `list_ports`.