### PR TITLE
Ensure the Windows USB interface number is reset and doesn't persist from previous loop iterations

### DIFF
--- a/serial/tools/list_ports_windows.py
+++ b/serial/tools/list_ports_windows.py
@@ -259,7 +259,6 @@ def iterate_comports():
 
     # repeat for all possible GUIDs
     for index in range(len(GUIDs)):
-        bInterfaceNumber = None
         g_hdi = SetupDiGetClassDevs(
             ctypes.byref(GUIDs[index]),
             None,
@@ -327,6 +326,7 @@ def iterate_comports():
             # in case of USB, make a more readable string, similar to that form
             # that we also generate on other platforms
             if szHardwareID_str.startswith('USB'):
+                bInterfaceNumber = None
                 m = re.search(r'VID_([0-9a-f]{4})(&PID_([0-9a-f]{4}))?(&MI_(\d{2}))?(\\(.*))?', szHardwareID_str, re.I)
                 if m:
                     info.vid = int(m.group(1), 16)


### PR DESCRIPTION
Fixes #802 

`bInterfaceNumber` was only being set to `None` in the outer _GUID_ loop, and not in a deeper loop over each _device_. Because of this, if a USB device didn't have multiple interfaces, but a previously enumerated USB device did have multiple interfaces, the value of `bInterfaceNumber` would still retain the old value and it would be incorrectly applied to the `location` string. The fix simply resets the variable for each COM port.

This is an example of a fictional sequence of devices, showing their locations before and after this fix.

| Order | Hardware ID | Interface | Location Before Fix | Correct | Location After FIx |
| ----- | ----------- | --------- | ------------------- | ------- | ------------------ |
| 1 | USB\VID_1111&PID_1111&MI_00 | 0 | 1-1.1:x.0 | Correct | 1-1.1:x.0 |
| 2 | USB\VID_2222&PID_2222 | None | 1-2.2:x.0 | Wrong | 1-2.2 |
| 3 | USB\VID_3333&PID_3333&MI_01 | 1 | 1-3.3:x.1 | Correct | 1-3.3:x.1 |
| 4 | USB\VID_4444&PID_4444 | None | 1-4.4:x.1 | Wrong | 1-4.4 |
| 5 | USB\VID_5555&PID_5555 | None | 1-5.5:x.1 | wrong | 1-5.5 |