### PR TITLE
Fix Read the Docs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: 'ubuntu-24.04'
+  tools:
+    python: '3.13'
+
+sphinx:
+  configuration: 'documentation/conf.py'
+  builder: 'html'
+  fail_on_warning: false
+
+python:
+  install:
+    - requirements: "documentation/requirements.txt"

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-#html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
This introduces the following changes:

* Add a `.readthedocs.yaml` config file. This file is now required by Read the Docs.
* Add a `documentation/requirements.txt` file. This allows the docs to be built locally.
* Configure Sphinx to use the Read the Docs theme. This ensures that the local and Read the Docs builds match.

When this merges, [Read the Docs builds should start passing](https://app.readthedocs.org/projects/pyserial/builds/). I'll monitor to confirm that this is the case, though.