### PR TITLE
SerialBase: set logger = None in base class constructor and nowhere else

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -389,7 +389,6 @@ class Serial(SerialBase):
         self._modemstate_timeout = Timeout(-1)
         self._remote_suspend_flow = False
         self._write_lock = None
-        self.logger = None
         self._ignore_set_control_answer = False
         self._poll_modem_state = False
         self._network_timeout = 3

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -200,6 +200,10 @@ class SerialBase(io.RawIOBase):
         self.is_open = False
         self.portstr = None
         self.name = None
+
+        # logging disabled by default but can be set to a Logger instance after __init__
+        self.logger = None
+
         # correct values are assigned below through properties
         self._port = None
         self._baudrate = None

--- a/serial/urlhandler/protocol_loop.py
+++ b/serial/urlhandler/protocol_loop.py
@@ -47,7 +47,6 @@ class Serial(SerialBase):
     def __init__(self, *args, **kwargs):
         self.buffer_size = 4096
         self.queue = None
-        self.logger = None
         self._cancel_write = False
         super(Serial, self).__init__(*args, **kwargs)
 
@@ -58,7 +57,6 @@ class Serial(SerialBase):
         """
         if self.is_open:
             raise SerialException("Port is already open.")
-        self.logger = None
         self.queue = queue.Queue(self.buffer_size)
 
         if self._port is None:

--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -53,7 +53,6 @@ class Serial(SerialBase):
         Open port with current settings. This may throw a SerialException
         if the port cannot be opened.
         """
-        self.logger = None
         if self._port is None:
             raise SerialException("Port must be configured before it can be used.")
         if self.is_open:

--- a/test/handlers/protocol_test.py
+++ b/test/handlers/protocol_test.py
@@ -29,7 +29,6 @@ class DummySerial(SerialBase):
     def open(self):
         """Open port with current settings. This may throw a SerialException
            if the port cannot be opened."""
-        self.logger = None
         if self._port is None:
             raise SerialException("Port must be configured before it can be used.")
         # not that there anything to configure...


### PR DESCRIPTION
Many child class implementations individually set logger=None inside their constructor or open() methods. Having this done only once in the base class constructor is simpler and also useful:

You can now always set the logger between `__init__` and `open` and get useful logging output from initialization code.

This is a more general version of
commit b63d94fd4e85 ("rfc2217: do not set logger = None inside open()") in #764