### PR TITLE
Update URLs to match current redirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -945,7 +945,7 @@ v1.0 - 2002-02-13
 =================
 
 - First public release.
-- Split from the pybsl application (see http://mspgcc.sourceforge.net)
+- Split from the pybsl application (see https://sourceforge.net/projects/mspgcc/)
 
 **New Features**
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -36,4 +36,4 @@ Individual files contain the following tag instead of the full license text.
     SPDX-License-Identifier:    BSD-3-Clause
 
 This enables machine processing of license information based on the SPDX
-License Identifiers that are here available: http://spdx.org/licenses/
+License Identifiers that are here available: https://spdx.org/licenses/

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ system). The module named "serial" automatically selects the
 appropriate backend.
 
 - Project Homepage: https://github.com/pyserial/pyserial
-- Download Page: https://pypi.python.org/pypi/pyserial
+- Download Page: https://pypi.org/project/pyserial/
 
 BSD license, (C) 2001-2020 Chris Liechti <cliechti@gmx.net>
 
@@ -20,7 +20,7 @@ Documentation
 For API documentation, usage and examples see files in the "documentation"
 directory.  The ".rst" files can be read in any text editor or being converted to
 HTML or PDF using Sphinx_. An HTML version is online at
-https://pythonhosted.org/pyserial/
+https://pyserial.readthedocs.io/en/latest/
 
 Examples
 ========
@@ -45,8 +45,8 @@ conda builds are available for linux, mac and windows.
 
 .. _`documentation/pyserial.rst`: https://github.com/pyserial/pyserial/blob/master/documentation/pyserial.rst#installation
 .. _examples: https://github.com/pyserial/pyserial/blob/master/examples
-.. _Python: http://python.org/
-.. _Sphinx: http://sphinx-doc.org/
+.. _Python: https://www.python.org/
+.. _Sphinx: https://www.sphinx-doc.org/
 .. |docs| image:: https://readthedocs.org/projects/pyserial/badge/?version=latest
-   :target: http://pyserial.readthedocs.io/
+   :target: https://pyserial.readthedocs.io/
    :alt: Documentation

--- a/documentation/appendix.rst
+++ b/documentation/appendix.rst
@@ -94,7 +94,7 @@ Parity on Raspberry Pi
     The Raspi has one full UART and a restricted one. On devices with built
     in wireless (WIFI/BT) use the restricted one on the GPIO header pins.
     If enhanced features are required, it is possible to swap UARTs, see
-    https://www.raspberrypi.org/documentation/configuration/uart.md
+    https://www.raspberrypi.com/documentation/computers/configuration.html#configure-uarts
 
 Support for Python 2.6 or earlier
     Support for older Python releases than 2.7 will not return to pySerial 3.x.
@@ -102,13 +102,13 @@ Support for Python 2.6 or earlier
     Python 2.6 or earlier, it is recommend to use pySerial `2.7`_
     (or any 2.x version).
 
-.. _`2.7`: https://pypi.python.org/pypi/pyserial/2.7
+.. _`2.7`: https://pypi.org/project/pyserial/2.7/
 
 
 Related software
 ================
 
-com0com - http://com0com.sourceforge.net/
+com0com - https://com0com.sourceforge.net/
     Provides virtual serial ports for Windows.
 
 

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -197,6 +197,5 @@ latex_logo = 'pyserial.png'
 
 # for external links to standard library
 intersphinx_mapping = {
-        #~ 'python': ('http://docs.python.org', None),
-        'py': ('http://docs.python.org', None),
+        'py': ('https://docs.python.org/3/', None),
         }

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -14,12 +14,11 @@ Other pages (online)
 
 - `project page on GitHub`_
 - `Download Page`_ with releases
-- This page, when viewed online is at https://pyserial.readthedocs.io/en/latest/ or
-  http://pythonhosted.org/pyserial/ .
+- This page, when viewed online, is at `<https://pyserial.readthedocs.io/en/latest/>`_.
 
-.. _Python: http://python.org/
+.. _Python: https://www.python.org/
 .. _`project page on GitHub`: https://github.com/pyserial/
-.. _`Download Page`: http://pypi.python.org/pypi/pyserial
+.. _`Download Page`: https://pypi.org/project/pyserial/
 
 
 Contents:

--- a/documentation/pyserial.rst
+++ b/documentation/pyserial.rst
@@ -19,13 +19,12 @@ Other pages (online)
 
 - `project page on GitHub`_
 - `Download Page`_ with releases (PyPi)
-- This page, when viewed online is at https://pyserial.readthedocs.io/en/latest/ or
-  http://pythonhosted.org/pyserial/ .
+- This page, when viewed online is at `<https://pyserial.readthedocs.io/en/latest/>`_.
 
-.. _Python: http://python.org/
+.. _Python: https://www.python.org/
 .. _LICENSE: appendix.html#license
 .. _`project page on GitHub`: https://github.com/pyserial/pyserial/
-.. _`Download Page`: http://pypi.python.org/pypi/pyserial
+.. _`Download Page`: https://pypi.org/project/pyserial/
 
 
 Features
@@ -86,12 +85,12 @@ pySerial can be installed from Conda::
 Currently the default conda channel will provide version 3.4 whereas the
 conda-forge channel provides the current 3.x version.
 
-Conda: https://www.continuum.io/downloads
+Conda: `<https://www.anaconda.com/download>`_
 
 From source (zip/tar.gz or checkout)
 ------------------------------------
-Download the archive from http://pypi.python.org/pypi/pyserial or
-https://github.com/pyserial/pyserial/releases.
+Download the archive from `<https://pypi.org/project/pyserial/>`_ or
+`<https://github.com/pyserial/pyserial/releases>`_.
 Unpack the archive, enter the ``pyserial-x.y`` directory and run::
 
     pip install .
@@ -111,12 +110,12 @@ Note that some distributions may package an older version of pySerial.
 These packages are created and maintained by developers working on
 these distributions.
 
-.. _PyPi: http://pypi.python.org/pypi/pyserial
+.. _PyPi: https://pypi.org/project/pyserial/
 
 
 References
 ==========
-* Python: http://www.python.org/
+* Python: https://www.python.org/
 
 
 Older Versions
@@ -134,7 +133,7 @@ win32all). WinXP is supported up to 3.0.1.
 
 
 .. _`old download`: https://sourceforge.net/projects/pyserial/files/pyserial/
-.. _download: https://pypi.python.org/simple/pyserial/
-.. _pywin32: http://pypi.python.org/pypi/pywin32
-.. _`2.7`: https://pypi.python.org/pypi/pyserial/2.7
+.. _download: https://pypi.org/simple/pyserial/
+.. _pywin32: https://pypi.org/project/pywin32/
+.. _`2.7`: https://pypi.org/project/pyserial/2.7/
 .. _`1.21`: https://sourceforge.net/projects/pyserial/files/pyserial/1.21/pyserial-1.21.zip/download

--- a/documentation/pyserial_api.rst
+++ b/documentation/pyserial_api.rst
@@ -1302,8 +1302,8 @@ is provided via a separate distribution `pyserial-asyncio`_.
 
 It is currently under development, see:
 
-- http://pyserial-asyncio.readthedocs.io/
+- https://pyserial-asyncio.readthedocs.io/en/latest/
 - https://github.com/pyserial/pyserial-asyncio
 
-.. _`pyserial-asyncio`: https://pypi.python.org/pypi/pyserial-asyncio
+.. _`pyserial-asyncio`: https://pypi.org/project/pyserial-asyncio/
 

--- a/documentation/shortintro.rst
+++ b/documentation/shortintro.rst
@@ -97,7 +97,7 @@ mode, it is advised to use io.TextIOWrapper_::
         print(hello == "hello\n")
 
 
-.. _io.TextIOWrapper: http://docs.python.org/library/io.html#io.TextIOWrapper
+.. _io.TextIOWrapper: https://docs.python.org/3/library/io.html#io.TextIOWrapper
 
 
 Testing ports

--- a/examples/at_protocol.py
+++ b/examples/at_protocol.py
@@ -3,8 +3,8 @@
 """
 Example of a AT command protocol.
 
-https://en.wikipedia.org/wiki/Hayes_command_set
-http://www.itu.int/rec/T-REC-V.250-200307-I/en
+https://en.wikipedia.org/wiki/Hayes_AT_command_set
+https://www.itu.int/rec/T-REC-V.250-200307-I/en
 """
 from __future__ import print_function
 

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -587,13 +587,13 @@ class Serial(SerialBase, PlatformSpecific):
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore BlockingIOErrors and EINTR. other errors are shown
-                # https://www.python.org/dev/peps/pep-0475.
+                # https://peps.python.org/pep-0475/.
                 if e.errno not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException(e.errno, f'read failed: {e}')
             except select.error as e:
                 # this is for Python 2.x
                 # ignore BlockingIOErrors and EINTR. all errors are shown
-                # see also http://www.python.org/dev/peps/pep-3151/#select
+                # see also https://peps.python.org/pep-3151/#select
                 if e[0] not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException('read failed: {}'.format(e))
             else:
@@ -661,13 +661,13 @@ class Serial(SerialBase, PlatformSpecific):
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore BlockingIOErrors and EINTR. other errors are shown
-                # https://www.python.org/dev/peps/pep-0475.
+                # https://peps.python.org/pep-0475/.
                 if e.errno not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException(e.errno, f'write failed: {e}')
             except select.error as e:
                 # this is for Python 2.x
                 # ignore BlockingIOErrors and EINTR. all errors are shown
-                # see also http://www.python.org/dev/peps/pep-3151/#select
+                # see also https://peps.python.org/pep-3151/#select
                 if e[0] not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException('write failed: {}'.format(e))
             if not timeout.is_non_blocking and timeout.expired():

--- a/serial/tools/list_ports_osx.py
+++ b/serial/tools/list_ports_osx.py
@@ -15,7 +15,7 @@
 # List all of the callout devices in OS/X by querying IOKit.
 
 # See the following for a reference of how to do this:
-# http://developer.apple.com/library/mac/#documentation/DeviceDrivers/Conceptual/WorkingWSerial/WWSerial_SerialDevs/SerialDevices.html#//apple_ref/doc/uid/TP30000384-CIHGEAFD
+# https://developer.apple.com/library/archive/documentation/DeviceDrivers/Conceptual/WorkingWSerial/WWSerial_SerialDevs/SerialDevices.html#//apple_ref/doc/uid/TP30000384-CIHGEAFD
 
 # More help from darwin_hid.py
 

--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -172,13 +172,13 @@ class Serial(SerialBase):
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore BlockingIOErrors and EINTR. other errors are shown
-                # https://www.python.org/dev/peps/pep-0475.
+                # https://peps.python.org/pep-0475/.
                 if e.errno not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException(e.errno, f'read failed: {e}')
             except (select.error, socket.error) as e:
                 # this is for Python 2.x
                 # ignore BlockingIOErrors and EINTR. all errors are shown
-                # see also http://www.python.org/dev/peps/pep-3151/#select
+                # see also https://peps.python.org/pep-3151/#select
                 if e[0] not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException('read failed: {}'.format(e))
             if timeout.expired():
@@ -225,13 +225,13 @@ class Serial(SerialBase):
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore BlockingIOErrors and EINTR. other errors are shown
-                # https://www.python.org/dev/peps/pep-0475.
+                # https://peps.python.org/pep-0475/.
                 if e.errno not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException(e.errno, f'write failed: {e}')
             except select.error as e:
                 # this is for Python 2.x
                 # ignore BlockingIOErrors and EINTR. all errors are shown
-                # see also http://www.python.org/dev/peps/pep-3151/#select
+                # see also https://peps.python.org/pep-3151/#select
                 if e[0] not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException('write failed: {}'.format(e))
             if not timeout.is_non_blocking and timeout.expired():
@@ -253,13 +253,13 @@ class Serial(SerialBase):
             except OSError as e:
                 # this is for Python 3.x where select.error is a subclass of
                 # OSError ignore BlockingIOErrors and EINTR. other errors are shown
-                # https://www.python.org/dev/peps/pep-0475.
+                # https://peps.python.org/pep-0475/.
                 if e.errno not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException(e.errno, f'read failed: {e}')
             except (select.error, socket.error) as e:
                 # this is for Python 2.x
                 # ignore BlockingIOErrors and EINTR. all errors are shown
-                # see also http://www.python.org/dev/peps/pep-3151/#select
+                # see also https://peps.python.org/pep-3151/#select
                 if e[0] not in (errno.EAGAIN, errno.EALREADY, errno.EWOULDBLOCK, errno.EINPROGRESS, errno.EINTR):
                     raise SerialException('read failed: {}'.format(e))
 

--- a/test/test.py
+++ b/test/test.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pyserial (http://pyserial.sf.net)  (C)2001-2015 cliechti@gmx.net
+Part of pyserial (https://github.com/pyserial/pyserial)  (C)2001-2015 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_advanced.py
+++ b/test/test_advanced.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pyserial (http://pyserial.sf.net)  (C)2002 cliechti@gmx.net
+Part of pyserial (https://github.com/pyserial/pyserial)  (C)2002 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pySerial (http://pyserial.sf.net)  (C)2001-2011 cliechti@gmx.net
+Part of pySerial (https://github.com/pyserial/pyserial)  (C)2001-2011 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_high_load.py
+++ b/test/test_high_load.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier:    BSD-3-Clause
 """Some tests for the serial module.
-Part of pyserial (http://pyserial.sf.net)  (C)2002-2003 cliechti@gmx.net
+Part of pyserial (https://github.com/pyserial/pyserial)  (C)2002-2003 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_iolib.py
+++ b/test/test_iolib.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pyserial (http://pyserial.sf.net)  (C)2001-2009 cliechti@gmx.net
+Part of pyserial (https://github.com/pyserial/pyserial)  (C)2001-2009 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pyserial (http://pyserial.sf.net)  (C)2010 cliechti@gmx.net
+Part of pyserial (https://github.com/pyserial/pyserial)  (C)2010 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.

--- a/test/test_settings_dict.py
+++ b/test/test_settings_dict.py
@@ -7,7 +7,7 @@
 """\
 Test the ability to get and set the settings with a dictionary.
 
-Part of pySerial (http://pyserial.sf.net)  (C) 2002-2015 cliechti@gmx.net
+Part of pySerial (https://github.com/pyserial/pyserial)  (C) 2002-2015 cliechti@gmx.net
 
 """
 

--- a/test/test_url.py
+++ b/test/test_url.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    BSD-3-Clause
 """\
 Some tests for the serial module.
-Part of pySerial (http://pyserial.sf.net)  (C)2001-2011 cliechti@gmx.net
+Part of pySerial (https://github.com/pyserial/pyserial)  (C)2001-2011 cliechti@gmx.net
 
 Intended to be run on different platforms, to ensure portability of
 the code.


### PR DESCRIPTION
This introduces the following changes:

* URLs that redirect have been updated.
* Some unadorned URLs in the documentation are updated to use RST embedded link syntax.
* A redirect that occurred when building the documentation has been addressed in `documentation/conf.py`.

The following message was displayed when building the docs, and this is fixed as a part of this change:

```
loading intersphinx inventory 'py' from https://docs.python.org/objects.inv ...
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
```