### PR TITLE
Fix a macOS test suite freeze and enable macOS in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         runner:
           - "ubuntu-24.04"
-          # - "macos-15"  # <-- Currently freezes midway through testing
+          - "macos-15"
           - "windows-2025"
 
     steps:

--- a/test/test_pty.py
+++ b/test/test_pty.py
@@ -9,16 +9,37 @@ Test PTY related functionality.
 """
 
 import os
+import queue
 import sys
+import threading
+import unittest
+
+import serial
 
 try:
     import pty
 except ImportError:
     pty = None
-import unittest
-import serial
 
 DATA = b'Hello\n'
+
+
+class Reader(threading.Thread):
+    def __init__(self, open_fd, result_queue):
+        super().__init__()
+        self.open_fd = open_fd
+        self.result_queue = result_queue
+
+    def run(self):
+        self.result_queue.put(self.open_fd.read(len(DATA)))
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.join()
+
 
 @unittest.skipIf(pty is None, "pty module not supported on platform")
 class Test_Pty_Serial_Open(unittest.TestCase):
@@ -41,12 +62,17 @@ class Test_Pty_Serial_Open(unittest.TestCase):
                 self.assertEqual(DATA, out)
 
     def test_pty_serial_read(self):
-        with serial.Serial(os.ttyname(self.slave), timeout=1) as slave:
-            with os.fdopen(self.master, "rb") as fd:
-                slave.write(DATA)
-                slave.flush()
-                out = fd.read(len(DATA))
-                self.assertEqual(DATA, out)
+        result_queue = queue.Queue()
+        with (
+            serial.Serial(os.ttyname(self.slave), timeout=1) as slave,
+            os.fdopen(self.master, "rb") as open_fd,
+            Reader(open_fd, result_queue),
+        ):
+            slave.write(DATA)
+            slave.flush()
+        out = result_queue.get()
+        result_queue.task_done()
+        self.assertEqual(DATA, out)
 
 if __name__ == '__main__':
     sys.stdout.write(__doc__)


### PR DESCRIPTION
This change allows the test suite to run on macOS by using a thread to read from the slave pty so a call to `termios.tcdrain()` can succeed (previously `termios.tcdrain()` would block on macOS for lack of a call to `.read()`).

From PR #822, which documents the underlying issue:

> The hang happens in `test_pty_serial_read` when it calls `slave.flush()`.
> This triggers `tcdrain()` which has different behavior on macOS vs Linux
> when dealing with PTY devices:
>
>    Linux: `tcdrain()` waits until data leaves the output buffer
>    macOS: `tcdrain()` waits until someone reads the data from the other end
>
> Since the test writes from the slave side before setting up a reader
> on the master, macOS blocks forever.
> This is a documented macOS kernel quirk (see #625, python/cpython#97001).

This PR most similarly follows suggestion 1 from #822 but keeps the call to `.flush()` instead of removing it.

Closes #654 