### PR TITLE
Retry `termios.tcdrain()` on EINTR

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -683,7 +683,14 @@ class Serial(SerialBase, PlatformSpecific):
         """
         if not self.is_open:
             raise PortNotOpenError()
-        termios.tcdrain(self.fd)
+        while True:
+            try:
+                termios.tcdrain(self.fd)
+                break
+            except termios.error as e:
+                if e.args[0] == errno.EINTR:
+                    continue
+                raise
 
     def _reset_input_buffer(self):
         """Clear input buffer, discarding all that is in the buffer."""


### PR DESCRIPTION
This was originally posted in PR #279, but needed to be updated to resolve merge conflicts and Python 2 syntax.

As noted in issue #278, although CPython has generally patched system calls to retry automatically on EINTR errors (see [PEP 475](https://peps.python.org/pep-0475/)), the CPython `tcdrain()` implementation doesn't appear to be catching and retrying, so this can still be an issue.

Fixes #278
Fixes #785 