### PR TITLE
Fix a build warning due to `documentation/Makefile` missing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,5 +34,3 @@ include test/test_url.py
 include documentation/*.rst
 include documentation/pyserial.png
 include documentation/conf.py
-include documentation/Makefile
-


### PR DESCRIPTION
This resolves the following warning when building the package [[recent example](https://github.com/pyserial/pyserial/actions/runs/19590421077/job/56107577228#step:5:36)]:

```
warning: no files found matching 'documentation/Makefile'
```