### PR TITLE
Migrate internal usage off deprecated interfaces

### DIFF
--- a/examples/wxTerminal.py
+++ b/examples/wxTerminal.py
@@ -271,7 +271,7 @@ class TerminalFrame(wx.Frame):
                 else:
                     self.StartThread()
                     self.SetTitle("Serial Terminal on {} [{},{},{},{}{}{}]".format(
-                        self.serial.portstr,
+                        self.serial.name,
                         self.serial.baudrate,
                         self.serial.bytesize,
                         self.serial.parity,

--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -35,7 +35,7 @@
 # - does not negotiate BINARY or COM_PORT_OPTION for his side but at least
 #   acknowledges that the client activates these options
 # - The configuration may be that the server prints a banner. As this client
-#   implementation does a flushInput on connect, this banner is hidden from
+#   implementation does a reset_input_buffer on connect, this banner is hidden from
 #   the user application.
 # - NOTIFY_MODEMSTATE: the poll interval of the server seems to be one
 #   second.
@@ -411,11 +411,11 @@ class Serial(SerialBase):
         if self.is_open:
             raise SerialException("Port is already open.")
         try:
-            self._socket = socket.create_connection(self.from_url(self.portstr), timeout=5)  # XXX good value?
+            self._socket = socket.create_connection(self.from_url(self.name), timeout=5)  # XXX good value?
             self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except Exception as msg:
             self._socket = None
-            raise SerialException("Could not open port {}: {}".format(self.portstr, msg))
+            raise SerialException("Could not open port {}: {}".format(self.name, msg))
 
         # use a thread save queue as buffer. it also simplifies implementing
         # the read timeout
@@ -498,9 +498,6 @@ class Serial(SerialBase):
         """Set communication parameters on opened port."""
         if self._socket is None:
             raise SerialException("Can only operate on open ports")
-
-        # if self._timeout != 0 and self._interCharTimeout is not None:
-            # XXX
 
         if self._write_timeout is not None:
             raise NotImplementedError('write_timeout is currently not supported')

--- a/serial/rs485.py
+++ b/serial/rs485.py
@@ -66,7 +66,7 @@ class RS485(serial.Serial):
         """Write to port, controlling RTS before and after transmitting."""
         if self._alternate_rs485_settings is not None:
             # apply level for TX and optional delay
-            self.setRTS(self._alternate_rs485_settings.rts_level_for_tx)
+            self.rts = self._alternate_rs485_settings.rts_level_for_tx
             if self._alternate_rs485_settings.delay_before_tx is not None:
                 time.sleep(self._alternate_rs485_settings.delay_before_tx)
             # write and wait for data to be written
@@ -75,7 +75,7 @@ class RS485(serial.Serial):
             # optional delay and apply level for RX
             if self._alternate_rs485_settings.delay_before_rx is not None:
                 time.sleep(self._alternate_rs485_settings.delay_before_rx)
-            self.setRTS(self._alternate_rs485_settings.rts_level_for_rx)
+            self.rts = self._alternate_rs485_settings.rts_level_for_rx
         else:
             super(RS485, self).write(b)
         return len(b)

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -326,7 +326,7 @@ class Serial(SerialBase, PlatformSpecific):
         self.fd = None
         # open
         try:
-            self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+            self.fd = os.open(self.name, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
         except OSError as msg:
             self.fd = None
             raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -530,7 +530,7 @@ class SerialBase(io.RawIOBase):
 
     def __repr__(self):
         """String representation of the current port settings and its state."""
-        return '{name}<id=0x{id:x}, open={p.is_open}>(port={p.portstr!r}, ' \
+        return '{name}<id=0x{id:x}, open={p.is_open}>(name={p.name!r}, ' \
                'baudrate={p.baudrate!r}, bytesize={p.bytesize!r}, parity={p.parity!r}, ' \
                'stopbits={p.stopbits!r}, timeout={p.timeout!r}, xonxoff={p.xonxoff!r}, ' \
                'rtscts={p.rtscts!r}, dsrdtr={p.dsrdtr!r})'.format(

--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -61,7 +61,7 @@ class Serial(SerialBase):
             0)
         if self._port_handle == win32.INVALID_HANDLE_VALUE:
             self._port_handle = None    # 'cause __del__ is called anyway
-            raise SerialException("could not open port {!r}: {!r}".format(self.portstr, ctypes.WinError()))
+            raise SerialException("could not open port {!r}: {!r}".format(self.name, ctypes.WinError()))
 
         try:
             self._overlapped_read = win32.OVERLAPPED()

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -726,11 +726,11 @@ class Miniterm(object):
             # reader thread needs to be shut down
             self._stop_reader()
             # save settings
-            settings = self.serial.getSettingsDict()
+            settings = self.serial.get_settings()
             try:
                 new_serial = serial.serial_for_url(port, do_not_open=True)
                 # restore settings and open
-                new_serial.applySettingsDict(settings)
+                new_serial.apply_settings(settings)
                 new_serial.rts = self.serial.rts
                 new_serial.dtr = self.serial.dtr
                 new_serial.open()

--- a/serial/urlhandler/protocol_cp2110.py
+++ b/serial/urlhandler/protocol_cp2110.py
@@ -82,7 +82,7 @@ class Serial(SerialBase):
 
         self._hid_handle = hid.device()
         try:
-            portpath = self.from_url(self.portstr)
+            portpath = self.from_url(self.name)
             self._hid_handle.open_path(portpath)
         except OSError as msg:
             raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))

--- a/serial/urlhandler/protocol_socket.py
+++ b/serial/urlhandler/protocol_socket.py
@@ -59,10 +59,10 @@ class Serial(SerialBase):
             raise SerialException("Port is already open.")
         try:
             # timeout is used for write timeout support :/ and to get an initial connection timeout
-            self._socket = socket.create_connection(self.from_url(self.portstr), timeout=POLL_TIMEOUT)
+            self._socket = socket.create_connection(self.from_url(self.name), timeout=POLL_TIMEOUT)
         except Exception as msg:
             self._socket = None
-            raise SerialException("Could not open port {}: {}".format(self.portstr, msg))
+            raise SerialException("Could not open port {}: {}".format(self.name, msg))
         # after connecting, switch to non-blocking, we're using select
         self._socket.setblocking(False)
 

--- a/test/handlers/protocol_test.py
+++ b/test/handlers/protocol_test.py
@@ -34,7 +34,7 @@ class DummySerial(SerialBase):
         # not that there anything to configure...
         self._reconfigurePort()
         # all things set up get, now a clean start
-        self._isOpen = True
+        self._is_open = True
 
     def _reconfigurePort(self):
         """Set communication parameters on opened port. for the test://
@@ -44,8 +44,8 @@ class DummySerial(SerialBase):
 
     def close(self):
         """Close port"""
-        if self._isOpen:
-            self._isOpen = False
+        if self._is_open:
+            self._is_open = False
 
     def makeDeviceName(self, port):
         raise SerialException("there is no sensible way to turn numbers into URLs")
@@ -77,19 +77,19 @@ class DummySerial(SerialBase):
 
     #  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
 
-    def inWaiting(self):
+    def in_waiting(self):
         """Return the number of characters currently in the input buffer."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         if self.logger:
             # set this one to debug as the function could be called often...
-            self.logger.debug('WARNING: inWaiting returns dummy value')
+            self.logger.debug('WARNING: in_waiting returns dummy value')
         return 0 # hmmm, see comment in read()
 
     def read(self, size=1):
         """Read size bytes from the serial port. If a timeout is set it may
         return less characters as requested. With no timeout it will block
         until the requested number of bytes is read."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         data = '123' # dummy data
         return bytes(data)
 
@@ -97,75 +97,94 @@ class DummySerial(SerialBase):
         """Output the given string over the serial port. Can block if the
         connection is blocked. May raise SerialException if the connection is
         closed."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         # nothing done
         return len(data)
 
-    def flushInput(self):
+    def reset_input_buffer(self):
         """Clear input buffer, discarding all that is in the buffer."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         if self.logger:
-            self.logger.info('ignored flushInput')
+            self.logger.info('ignored reset_input_buffer')
 
-    def flushOutput(self):
+    def reset_output_buffer(self):
         """Clear output buffer, aborting the current output and
         discarding all that is in the buffer."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         if self.logger:
-            self.logger.info('ignored flushOutput')
+            self.logger.info('ignored reset_output_buffer')
 
-    def sendBreak(self, duration=0.25):
+    def send_break(self, duration=0.25):
         """Send break condition. Timed, returns to idle state after given
         duration."""
-        if not self._isOpen: raise PortNotOpenError()
+        if not self._is_open: raise PortNotOpenError()
         if self.logger:
-            self.logger.info('ignored sendBreak({!r})'.format(duration))
+            self.logger.info('ignored send_break({!r})'.format(duration))
 
-    def setBreak(self, level=True):
+    @property
+    def break_condition(self):
         """Set break: Controls TXD. When active, to transmitting is
         possible."""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('ignored setBreak({!r})'.format(level))
-
-    def setRTS(self, level=True):
-        """Set terminal status line: Request To Send"""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('ignored setRTS({!r})'.format(level))
-
-    def setDTR(self, level=True):
-        """Set terminal status line: Data Terminal Ready"""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('ignored setDTR({!r})'.format(level))
-
-    def getCTS(self):
-        """Read terminal status line: Clear To Send"""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('returning dummy for getCTS()')
-        return True
-
-    def getDSR(self):
-        """Read terminal status line: Data Set Ready"""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('returning dummy for getDSR()')
-        return True
-
-    def getRI(self):
-        """Read terminal status line: Ring Indicator"""
-        if not self._isOpen: raise PortNotOpenError()
-        if self.logger:
-            self.logger.info('returning dummy for getRI()')
         return False
 
-    def getCD(self):
-        """Read terminal status line: Carrier Detect"""
-        if not self._isOpen: raise PortNotOpenError()
+    @break_condition.setter
+    def break_condition(self, level=True):
+        if not self._is_open: raise PortNotOpenError()
         if self.logger:
-            self.logger.info('returning dummy for getCD()')
+            self.logger.info(f'ignored break_condition = {level!r}')
+
+    @property
+    def rts(self):
+        return False
+
+    @rts.setter
+    def rts(self, level=True):
+        """Set terminal status line: Request To Send"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info(f'ignored rts = {level!r}')
+
+    @property
+    def dtr(self):
+        return False
+
+    @dtr.setter
+    def dtr(self, level=True):
+        """Set terminal status line: Data Terminal Ready"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info(f'ignored dtr = {level!r}')
+
+    @property
+    def cts(self):
+        """Read terminal status line: Clear To Send"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info('returning dummy for cts')
+        return True
+
+    @property
+    def dsr(self):
+        """Read terminal status line: Data Set Ready"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info('returning dummy for dsr')
+        return True
+
+    @property
+    def ri(self):
+        """Read terminal status line: Ring Indicator"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info('returning dummy for ri')
+        return False
+
+    @property
+    def cd(self):
+        """Read terminal status line: Carrier Detect"""
+        if not self._is_open: raise PortNotOpenError()
+        if self.logger:
+            self.logger.info('returning dummy for cd')
         return True
 
     # - - - platform specific - - -

--- a/test/test.py
+++ b/test/test.py
@@ -142,7 +142,7 @@ class Test2_Forever(unittest.TestCase):
     def tearDown(self):
         self.s.close()
 
-    def test1_inWaitingEmpty(self):
+    def test1_in_waiting_empty(self):
         """no timeout: after port open, the input buffer must be empty (in_waiting)"""
         self.assertEqual(self.s.in_waiting, 0, "expected empty buffer")
 
@@ -208,7 +208,7 @@ class Test_MoreTimeouts(unittest.TestCase):
         self.s.read(3000)
         self.s.close()
 
-    def test_WriteTimeout(self):
+    def test_write_timeout(self):
         """Test write() timeout."""
         # use xonxoff setting and the loop-back adapter to switch traffic on hold
         self.s.port = PORT

--- a/test/test_advanced.py
+++ b/test/test_advanced.py
@@ -38,12 +38,12 @@ class Test_ChangeAttributes(unittest.TestCase):
 
     def test_PortSetting(self):
         self.s.port = PORT
-        self.assertEqual(self.s.portstr.lower(), PORT.lower())
+        self.assertEqual(self.s.name.lower(), PORT.lower())
         # test internals
         self.assertEqual(self.s._port, PORT)
         # test on the fly change
         self.s.open()
-        self.assertTrue(self.s.isOpen())
+        self.assertTrue(self.s.is_open)
 
     def test_DoubleOpen(self):
         self.s.open()
@@ -143,11 +143,11 @@ class Test_ChangeAttributes(unittest.TestCase):
     def test_PortOpenClose(self):
         for i in range(3):
             # open the port and check flag
-            self.assertTrue(not self.s.isOpen())
+            self.assertTrue(not self.s.is_open)
             self.s.open()
-            self.assertTrue(self.s.isOpen())
+            self.assertTrue(self.s.is_open)
             self.s.close()
-            self.assertTrue(not self.s.isOpen())
+            self.assertTrue(not self.s.is_open)
 
 
 if __name__ == '__main__':

--- a/test/test_cancel.py
+++ b/test/test_cancel.py
@@ -46,7 +46,7 @@ class TestCancelRead(unittest.TestCase):
         t2 = time.time()
         self.assertEqual(self.cancel_called, 1)
         self.assertTrue(0.5 < (t2 - t1) < 2.5, 'Function did not return in time: {}'.format(t2 - t1))
-        #~ self.assertTrue(not self.s.isOpen())
+        #~ self.assertTrue(not self.s.is_open)
         #~ self.assertRaises(serial.SerialException, self.s.open)
 
     #~ def test_cancel_before_read(self):
@@ -90,7 +90,7 @@ class TestCancelWrite(unittest.TestCase):
         t2 = time.time()
         self.assertEqual(self.cancel_called, 1)
         self.assertTrue(0.5 < (t2 - t1) < 2.5, 'Function did not return in time: {}'.format(t2 - t1))
-        #~ self.assertTrue(not self.s.isOpen())
+        #~ self.assertTrue(not self.s.is_open)
         #~ self.assertRaises(serial.SerialException, self.s.open)
 
     #~ def test_cancel_before_write(self):

--- a/test/test_high_load.py
+++ b/test/test_high_load.py
@@ -53,7 +53,7 @@ class TestHighLoad(unittest.TestCase):
             q = bytes_0to255
             self.s.write(q)
             self.assertEqual(self.s.read(len(q)), q)  # expected same which was written before
-        self.assertEqual(self.s.inWaiting(), 0)  # expected empty buffer after all sent chars are read
+        self.assertEqual(self.s.in_waiting, 0)  # expected empty buffer after all sent chars are read
 
     def test1_WriteWriteReadLoopback(self):
         """Send big strings, multiple write one read."""
@@ -62,7 +62,7 @@ class TestHighLoad(unittest.TestCase):
             self.s.write(q)
         read = self.s.read(len(q) * self.N)
         self.assertEqual(read, q * self.N, "expected what was written before. got {} bytes, expected {}".format(len(read), self.N * len(q)))
-        self.assertEqual(self.s.inWaiting(), 0)  # "expected empty buffer after all sent chars are read")
+        self.assertEqual(self.s.in_waiting, 0)  # "expected empty buffer after all sent chars are read")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This introduces the following changes to migrate internal usage of deprecated interfaces to use supported interfaces:

* `.portstr` -> `.name`
* `.setRTS()` -> `.rts`
* `.getSettingsDict()` -> `.get_settings()`
* `.applySettingsDict()` -> `.apply_settings()`
* `.inWaiting()` -> `.in_waiting`
* `.isOpen()` -> `.is_open`

In addition, the test suite's `DummySerial` class is updated, and commented-out code is updated.