### PR TITLE
Remove `time.sleep()` calls from `test_threaded.py`

### DIFF
--- a/test/test_threaded.py
+++ b/test/test_threaded.py
@@ -8,17 +8,17 @@
 Test serial.threaded related functionality.
 """
 
-import os
 import queue
 import unittest
+
 import serial
 import serial.threaded
-
 
 # on which port should the tests be performed:
 PORT = 'loop://'
 
-class Test_threaded(unittest.TestCase):
+
+class TestThreaded(unittest.TestCase):
     """Test serial.threaded related functionality"""
 
     def test_line_reader(self):
@@ -66,14 +66,3 @@ def retrieve_item(target_queue: queue.Queue) -> str | bytes:
     line = target_queue.get(timeout=1)
     target_queue.task_done()
     return line
-
-
-if __name__ == '__main__':
-    import sys
-    sys.stdout.write(__doc__)
-    if len(sys.argv) > 1:
-        PORT = sys.argv[1]
-    sys.stdout.write("Testing port: {!r}\n".format(PORT))
-    sys.argv[1:] = ['-v']
-    # When this module is executed from the command-line, it runs all its tests
-    unittest.main()


### PR DESCRIPTION
This change reduces the test suite runtime from ~11 seconds to ~9 seconds by replacing two calls to `time.sleep()` in `test_threaded.py` with a queue that blocks only exactly the amount of time required for a reader thread to put its data to the queue.

In a follow-up commit, `test_threaded.py` was run through a number of linters to resolve code quality and style issues.