### PR TITLE
Fixup `test_readline.py`

### DIFF
--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -22,20 +22,12 @@ On a 9 pole DSUB these are the pins (2-3) (4-6) (7-8)
 """
 
 import unittest
-import sys
 import serial
 
 #~ print serial.VERSION
 
 # on which port should the tests be performed:
 PORT = 'loop://'
-
-if sys.version_info >= (3, 0):
-    def data(string):
-        return bytes(string, 'latin1')
-else:
-    def data(string):
-        return string
 
 
 class Test_Readline(unittest.TestCase):
@@ -64,15 +56,6 @@ class Test_Readline(unittest.TestCase):
                 [serial.to_bytes([0x31, 0x0a]), serial.to_bytes([0x32, 0x0a]), serial.to_bytes([0x33, 0x0a])]
                 )
 
-    def test_xreadlines(self):
-        """Test xreadlines method (skipped for io based systems)"""
-        if hasattr(self.s, 'xreadlines'):
-            self.s.write(serial.to_bytes([0x31, 0x0a, 0x32, 0x0a, 0x33, 0x0a]))
-            self.assertEqual(
-                    list(self.s.xreadlines()),
-                    [serial.to_bytes([0x31, 0x0a]), serial.to_bytes([0x32, 0x0a]), serial.to_bytes([0x33, 0x0a])]
-                    )
-
     def test_for_in(self):
         """Test for line in s"""
         self.s.write(serial.to_bytes([0x31, 0x0a, 0x32, 0x0a, 0x33, 0x0a]))
@@ -83,14 +66,6 @@ class Test_Readline(unittest.TestCase):
                 lines,
                 [serial.to_bytes([0x31, 0x0a]), serial.to_bytes([0x32, 0x0a]), serial.to_bytes([0x33, 0x0a])]
                 )
-
-    def test_alternate_eol(self):
-        """Test readline with alternative eol settings (skipped for io based systems)"""
-        if hasattr(self.s, 'xreadlines'):  # test if it is our FileLike base class
-            self.s.write(serial.to_bytes("no\rno\nyes\r\n"))
-            self.assertEqual(
-                    self.s.readline(eol=serial.to_bytes("\r\n")),
-                    serial.to_bytes("no\rno\nyes\r\n"))
 
 
 if __name__ == '__main__':

--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -41,31 +41,23 @@ class Test_Readline(unittest.TestCase):
 
     def test_readline(self):
         """Test readline method"""
-        self.s.write(serial.to_bytes([0x31, 0x0a, 0x32, 0x0a, 0x33, 0x0a]))
-        self.assertEqual(self.s.readline(), serial.to_bytes([0x31, 0x0a]))
-        self.assertEqual(self.s.readline(), serial.to_bytes([0x32, 0x0a]))
-        self.assertEqual(self.s.readline(), serial.to_bytes([0x33, 0x0a]))
+        self.s.write(b'1\n2\n3\n')
+        self.assertEqual(self.s.readline(), b'1\n')
+        self.assertEqual(self.s.readline(), b'2\n')
+        self.assertEqual(self.s.readline(), b'3\n')
         # this time we will get a timeout
-        self.assertEqual(self.s.readline(), serial.to_bytes([]))
+        self.assertEqual(self.s.readline(), b'')
 
     def test_readlines(self):
         """Test readlines method"""
-        self.s.write(serial.to_bytes([0x31, 0x0a, 0x32, 0x0a, 0x33, 0x0a]))
-        self.assertEqual(
-                self.s.readlines(),
-                [serial.to_bytes([0x31, 0x0a]), serial.to_bytes([0x32, 0x0a]), serial.to_bytes([0x33, 0x0a])]
-                )
+        self.s.write(b'1\n2\n3\n')
+        self.assertEqual(self.s.readlines(), [b'1\n', b'2\n', b'3\n'])
 
-    def test_for_in(self):
-        """Test for line in s"""
-        self.s.write(serial.to_bytes([0x31, 0x0a, 0x32, 0x0a, 0x33, 0x0a]))
-        lines = []
-        for line in self.s:
-            lines.append(line)
-        self.assertEqual(
-                lines,
-                [serial.to_bytes([0x31, 0x0a]), serial.to_bytes([0x32, 0x0a]), serial.to_bytes([0x33, 0x0a])]
-                )
+    def test_dunder_iter(self):
+        """Test `s.__iter__()` (used in `for line in s`, for example)."""
+        self.s.write(b'1\n2\n3\n')
+        lines = list(self.s)
+        self.assertEqual(lines, [b'1\n', b'2\n', b'3\n'])
 
 
 if __name__ == '__main__':

--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -14,7 +14,7 @@ import serial
 
 @pytest.fixture
 def port() -> typing.Iterable[serial.Serial]:
-    port_ = serial.serial_for_url("loop://", timeout=1)
+    port_ = serial.serial_for_url("loop://", timeout=0.0)
     yield port_
     port_.close()
 

--- a/test/test_readline.py
+++ b/test/test_readline.py
@@ -4,68 +4,39 @@
 # (C) 2010-2015 Chris Liechti <cliechti@gmx.net>
 #
 # SPDX-License-Identifier:    BSD-3-Clause
-"""\
-Some tests for the serial module.
-Part of pyserial (https://github.com/pyserial/pyserial)  (C)2010 cliechti@gmx.net
 
-Intended to be run on different platforms, to ensure portability of
-the code.
+import typing
 
-For all these tests a simple hardware is required.
-Loopback HW adapter:
-Shortcut these pin pairs:
- TX  <-> RX
- RTS <-> CTS
- DTR <-> DSR
+import pytest
 
-On a 9 pole DSUB these are the pins (2-3) (4-6) (7-8)
-"""
-
-import unittest
 import serial
 
-#~ print serial.VERSION
 
-# on which port should the tests be performed:
-PORT = 'loop://'
-
-
-class Test_Readline(unittest.TestCase):
-    """Test readline function"""
-
-    def setUp(self):
-        self.s = serial.serial_for_url(PORT, timeout=1)
-
-    def tearDown(self):
-        self.s.close()
-
-    def test_readline(self):
-        """Test readline method"""
-        self.s.write(b'1\n2\n3\n')
-        self.assertEqual(self.s.readline(), b'1\n')
-        self.assertEqual(self.s.readline(), b'2\n')
-        self.assertEqual(self.s.readline(), b'3\n')
-        # this time we will get a timeout
-        self.assertEqual(self.s.readline(), b'')
-
-    def test_readlines(self):
-        """Test readlines method"""
-        self.s.write(b'1\n2\n3\n')
-        self.assertEqual(self.s.readlines(), [b'1\n', b'2\n', b'3\n'])
-
-    def test_dunder_iter(self):
-        """Test `s.__iter__()` (used in `for line in s`, for example)."""
-        self.s.write(b'1\n2\n3\n')
-        lines = list(self.s)
-        self.assertEqual(lines, [b'1\n', b'2\n', b'3\n'])
+@pytest.fixture
+def port() -> typing.Iterable[serial.Serial]:
+    port_ = serial.serial_for_url("loop://", timeout=1)
+    yield port_
+    port_.close()
 
 
-if __name__ == '__main__':
-    import sys
-    sys.stdout.write(__doc__)
-    if len(sys.argv) > 1:
-        PORT = sys.argv[1]
-    sys.stdout.write("Testing port: {!r}\n".format(PORT))
-    sys.argv[1:] = ['-v']
-    # When this module is executed from the command-line, it runs all its tests
-    unittest.main()
+def test_readline(port):
+    """Test readline method"""
+    port.write(b'1\n2\n3\n')
+    assert port.readline() == b'1\n'
+    assert port.readline() == b'2\n'
+    assert port.readline() == b'3\n'
+    # this time we will get a timeout
+    assert port.readline() == b''
+
+
+def test_readlines(port):
+    """Test readlines method"""
+    port.write(b'1\n2\n3\n')
+    assert port.readlines() == [b'1\n', b'2\n', b'3\n']
+
+
+def test_dunder_iter(port):
+    """Test `s.__iter__()` (used in `for line in s`, for example)."""
+    port.write(b'1\n2\n3\n')
+    lines = list(port)
+    assert lines == [b'1\n', b'2\n', b'3\n']


### PR DESCRIPTION
This introduces the following changes:

* Remove Python 2 compatibility code
* Use bytes literals for clarity
* Use pytest, not unittest, for simplicity
* Remove a timeout in the test code, which reduces test suite runtimes by ~3 seconds
