### PR TITLE
Recursively include Python test files in `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,18 +18,7 @@ include examples/wxSerialConfigDialog.wxg
 include examples/wxTerminal.py
 include examples/wxTerminal.wxg
 
-include test/handlers/__init__.py
-include test/handlers/protocol_test.py
-include test/run_all_tests.py
-include test/test_advanced.py
-include test/test_high_load.py
-include test/test_iolib.py
-include test/test.py
-include test/test_readline.py
-include test/test_rfc2217.py
-include test/test_rs485.py
-include test/test_settings_dict.py
-include test/test_url.py
+recursive-include test/ *.py
 
 include documentation/*.rst
 include documentation/pyserial.png


### PR DESCRIPTION
The manifest `include` directives were too granular to maintain, and had fallen out of sync with the number of test files in the `test/` directory.