### PR TITLE
Thoroughly test the `Timeout` class

### DIFF
--- a/test/test_timeout_class.py
+++ b/test/test_timeout_class.py
@@ -1,66 +1,70 @@
-#!/usr/bin/env python
-#
 # This file is part of pySerial - Cross platform serial port support for Python
 # (C) 2016 Chris Liechti <cliechti@gmx.net>
 #
 # SPDX-License-Identifier:    BSD-3-Clause
+
 """
 Test Timeout helper class.
 """
-import sys
-import unittest
-import time
+
 from serial import serialutil
 
 
-class TestTimeoutClass(unittest.TestCase):
-    """Test the Timeout class"""
+def test_simple_timeout(monkeypatch):
+    """Test simple timeout"""
 
-    def test_simple_timeout(self):
-        """Test simple timeout"""
-        t = serialutil.Timeout(2)
-        self.assertFalse(t.expired())
-        self.assertTrue(t.time_left() > 0)
-        time.sleep(2.1)
-        self.assertTrue(t.expired())
-        self.assertEqual(t.time_left(), 0)
+    # Force `time.monotonic()` to return a fixed value.
+    monkeypatch.setattr("time.monotonic", lambda: 0.0)
 
-    def test_non_blocking(self):
-        """Test nonblocking case (0)"""
-        t = serialutil.Timeout(0)
-        self.assertTrue(t.is_non_blocking)
-        self.assertFalse(t.is_infinite)
-        self.assertTrue(t.expired())
+    t = serialutil.Timeout(2)
+    assert t.expired() is False
+    assert t.time_left() == 2.0
 
-    def test_blocking(self):
-        """Test no timeout (None)"""
-        t = serialutil.Timeout(None)
-        self.assertFalse(t.is_non_blocking)
-        self.assertTrue(t.is_infinite)
-        #~ self.assertFalse(t.expired())
-
-    def test_changing_clock(self):
-        """Test recovery from changing clock"""
-        class T(serialutil.Timeout):
-            def TIME(self):
-                return test_time
-        test_time = 1000
-        t = T(10)
-        self.assertEqual(t.target_time, 1010)
-        self.assertFalse(t.expired())
-        self.assertTrue(t.time_left() > 0)
-        test_time = 100  # clock jumps way back
-        self.assertTrue(t.time_left() > 0)
-        self.assertTrue(t.time_left() <= 10)
-        self.assertEqual(t.target_time, 110)
-        test_time = 10000  # jump way forward
-        self.assertEqual(t.time_left(), 0)  # if will expire immediately
+    # Travel forward in time by 2.1 seconds.
+    monkeypatch.setattr("time.monotonic", lambda: 2.1)
+    assert t.expired() is True
+    assert t.time_left() == 0.0
 
 
-if __name__ == '__main__':
-    sys.stdout.write(__doc__)
-    if len(sys.argv) > 1:
-        PORT = sys.argv[1]
-    sys.argv[1:] = ['-v']
-    # When this module is executed from the command-line, it runs all its tests
-    unittest.main()
+def test_non_blocking(monkeypatch):
+    """Test nonblocking case (0)."""
+
+    # Force `time.monotonic()` to return a fixed value.
+    monkeypatch.setattr("time.monotonic", lambda: 100.0)
+
+    t = serialutil.Timeout(0)
+    assert t.is_non_blocking is True
+    assert t.is_infinite is False
+    assert t.expired() is True
+
+    # Travel backwards in time to confirm that `expired()` isn't calculating anything.
+    monkeypatch.setattr("time.monotonic", lambda: 0.0)
+    assert t.expired() is True
+
+
+def test_blocking(monkeypatch):
+    """Test no timeout (None)"""
+
+    # Force `time.monotonic()` to return a fixed value.
+    monkeypatch.setattr("time.monotonic", lambda: 0.0)
+
+    t = serialutil.Timeout(None)
+    assert t.is_non_blocking is False
+    assert t.is_infinite is True
+    assert t.expired() is False
+
+    # Test expiration behavior 100 years in the future.
+    monkeypatch.setattr("time.monotonic", lambda: 3_153_600_000.0)
+    assert t.expired() is False
+
+
+def test_restart(monkeypatch):
+    """Test the `restart()` method."""
+
+    monkeypatch.setattr("time.monotonic", lambda: 0.0)
+    t = serialutil.Timeout(1.0)
+    monkeypatch.setattr("time.monotonic", lambda: 2.0)
+    assert t.expired() is True
+
+    t.restart(1.0)
+    assert t.expired() is False


### PR DESCRIPTION
This introduces the following changes to the `Timeout` class:

* Eliminate `TIME` and just use `time.monotonic()`.
* Eliminate conditionals that check for time having jumped. (`time.monotonic()` guarantees time always moves forward.)
* Add type annotations and fix issues reported by mypy.

Also, these changes were introduced to `test_timeout_class.py`:

* Remove `time.sleep()` calls in favor of mocking. This reduces the test suite runtime by ~2.1 seconds.
* Use pytest constructs, not unittest.

This PR supersedes #231.