### PR TITLE
Add tag-based release workflow and migrate to setuptools-scm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,71 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+jobs:
+  test:
+    uses: "./.github/workflows/test.yaml"
+
+  build:
+    name: "Build"
+    needs: test
+    runs-on: "ubuntu-24.04"
+
+    steps:
+      - uses: "actions/checkout@v5"
+        with:
+          fetch-depth: 0
+
+      - uses: "astral-sh/setup-uv@v6"
+
+      - name: "Build sdist and wheel"
+        run: |
+          uv build --out-dir dist/
+
+      - uses: "actions/upload-artifact@v4"
+        with:
+          name: dist
+          path: "dist/"
+          if-no-files-found: error
+
+  github-release:
+    name: "GitHub Release"
+    needs: build
+    runs-on: "ubuntu-24.04"
+    permissions:
+      contents: write
+
+    steps:
+      - uses: "actions/download-artifact@v4"
+        with:
+          name: dist
+          path: "dist/"
+
+      - uses: "softprops/action-gh-release@v2.5.0"
+        with:
+          files: "dist/*"
+          prerelease: "${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'dev') }}"
+          generate_release_notes: true
+
+  pypi-publish:
+    name: "Publish to PyPI"
+    needs: build
+    runs-on: "ubuntu-24.04"
+    environment: pypi
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: "actions/download-artifact@v4"
+        with:
+          name: dist
+          path: "dist/"
+
+      - uses: "astral-sh/setup-uv@v6"
+
+      - name: "Publish to PyPI"
+        run: |
+          uv publish --trusted-publishing always dist/*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+  workflow_call: null
 
 jobs:
   test:
@@ -24,6 +25,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v5"
+        with:
+          fetch-depth: 0
       - uses: "actions/setup-python@v6"
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: "1"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,8 +25,6 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v5"
-        with:
-          fetch-depth: 0
       - uses: "actions/setup-python@v6"
         env:
           PIP_DISABLE_PIP_VERSION_CHECK: "1"
@@ -44,6 +42,8 @@ jobs:
       - name: "Run test suite"
         env:
           TOX_SKIP_ENV: "coverage-html"
+          # Shallow clones may not have tags; exact version not needed for tests.
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0"
         run: |
           tox
 
@@ -75,5 +75,7 @@ jobs:
         shell: "bash -o igncr {0}"
         env:
           TOX_SKIP_ENV: "coverage-html"
+          # Shallow clones may not have tags; exact version not needed for tests.
+          SETUPTOOLS_SCM_PRETEND_VERSION: "0.0.0"
         run: |
           python3.12 -m tox

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ documentation/_build
 build
 dist
 *.egg-info
+serial/_version.py
 
 .idea
 venv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,5 @@
+# RTD dashboard should be configured to only activate tagged versions
+# to avoid dev version strings (e.g. 3.6.dev81+g...) in published docs.
 version: 2
 
 build:
@@ -15,3 +17,5 @@ sphinx:
 python:
   install:
     - requirements: "requirements/docs/requirements.txt"
+    - method: pip
+      path: .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Unreleased
 ==========
 
 
+**Build**
+
+- Version is now derived from git tags via ``setuptools-scm`` rather than
+  a hardcoded string in ``serial/__init__.py``.
+
 **Python support**
 
 - Support Python 3.10 and higher.

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -11,13 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.append(os.path.abspath('..'))
-
 import serial
 
 # -- General configuration -----------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,11 @@ Source = "https://github.com/pyserial/pyserial"
 Documentation = "https://pyserial.readthedocs.io/en/latest/"
 
 [build-system]
-requires = ["setuptools>=77.0.3"]
+requires = ["setuptools>=77.0.3", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.dynamic]
-version = {attr = "serial.__version__"}
+[tool.setuptools_scm]
+version_file = "serial/_version.py"
 
 
 # coverage

--- a/serial/__init__.py
+++ b/serial/__init__.py
@@ -15,7 +15,14 @@ import importlib
 from serial.serialutil import *
 #~ SerialBase, SerialException, to_bytes, iterbytes
 
-__version__ = '3.5'
+try:
+    from serial._version import __version__
+except ImportError:
+    from importlib.metadata import version, PackageNotFoundError
+    try:
+        __version__ = version("pyserial")
+    except PackageNotFoundError:
+        __version__ = "0.0.0+unknown"
 
 VERSION = __version__
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,10 @@ commands =
     coverage run -m pytest {posargs:}
 
 
+[testenv:build_wheel]
+pass_env = SETUPTOOLS_SCM_PRETEND_VERSION
+
+
 [testenv:coverage-base]
 description = Base settings for coverage-* environments
 base_python = py3.14
@@ -75,7 +79,6 @@ description = Test the documentation builds
 # The Python version here must match the version set in `.readthedocs.yaml`
 # to help ensure documentation builds are tested in a reproducible way.
 base_python = py3.13
-skip_install = true
 deps =
     -r requirements/docs/requirements.txt
 commands =


### PR DESCRIPTION
## Summary

- Tag-triggered GitHub Actions release workflow publishing to GitHub Releases and PyPI via trusted publishing (OIDC)
- setuptools-scm migration replacing hardcoded `__version__` with git-tag-derived versioning
- tox docs environment now installs the package (`skip_install = true` removed) because setuptools-scm requires an actual install to resolve the version; the `sys.path` hack in `conf.py` is removed accordingly

## Setup required

### GitHub

1. Create a **`pypi`** environment in repo Settings > Environments
2. Optionally add environment protection rules (e.g. restrict to `v*` tags, require approval)

### PyPI

1. On pypi.org, go to the `pyserial` project > Publishing > Add a new publisher
2. Configure the trusted publisher with:
   - Owner: `pyserial`
   - Repository: `pyserial`
   - Workflow: `release.yaml`
   - Environment: `pypi`

### Read the Docs

1. In the RTD dashboard, configure version activation to only activate tagged versions to avoid dev version strings (e.g. `3.6.dev81+gabcdef`) in published docs

## Usage

Tag a commit on master and push:

```
git tag v3.6.0
git push origin v3.6.0
```

The workflow runs the test suite, builds sdist + wheel with uv, then publishes to GitHub Releases and PyPI in parallel. Pre-release tags (e.g. `v3.6.0rc1`) are detected automatically.