### PR TITLE
serialposix: Use weakref.finalize to prevent interpreter shutdown warning

### DIFF
--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -37,6 +37,7 @@ import select
 import struct
 import sys
 import termios
+import weakref
 
 import serial
 from serial.serialutil import SerialBase, SerialException, to_bytes, \
@@ -279,6 +280,11 @@ else:
         pass
 
 
+def _close_fds(*fds):
+    for fd in fds:
+        os.close(fd)
+
+
 # load some constants for later use.
 # try to use values from termios, use defaults from linux otherwise
 TIOCMGET = getattr(termios, 'TIOCMGET', 0x5415)
@@ -330,6 +336,7 @@ class Serial(SerialBase, PlatformSpecific):
         if self.is_open:
             raise SerialException("Port is already open.")
         self.fd = None
+        self._finalizer = None
         # open
         try:
             self.fd = os.open(self.name, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
@@ -381,6 +388,16 @@ class Serial(SerialBase, PlatformSpecific):
                 self.pipe_abort_write_r = None
 
             raise
+
+        self._finalizer = weakref.finalize(
+            self,
+            _close_fds,
+            self.fd,
+            self.pipe_abort_read_r,
+            self.pipe_abort_read_w,
+            self.pipe_abort_write_r,
+            self.pipe_abort_write_w,
+        )
 
         self.is_open = True
 
@@ -534,12 +551,10 @@ class Serial(SerialBase, PlatformSpecific):
         """Close port"""
         if self.is_open:
             if self.fd is not None:
-                os.close(self.fd)
+                if self._finalizer is not None:
+                    self._finalizer()
+                    self._finalizer = None
                 self.fd = None
-                os.close(self.pipe_abort_read_w)
-                os.close(self.pipe_abort_read_r)
-                os.close(self.pipe_abort_write_w)
-                os.close(self.pipe_abort_write_r)
                 self.pipe_abort_read_r, self.pipe_abort_read_w = None, None
                 self.pipe_abort_write_r, self.pipe_abort_write_w = None, None
             self.is_open = False


### PR DESCRIPTION
At interpreter shutdown, `close()` is called by `io.RawIOBase.__del__`, but can fail due to the global module `os` being torn down already and replaced with `None`, resulting in a warning about an ignored exception being printed to stderr at interpreter exit

The order modules are torn down is somewhat arbitrary, but this reliably triggers for me in Python 3.14 on Arch Linux if I've imported the `subprocess` module first (same behaviour with either pyserial 3.5 or git master):

```bash
$ python
Python 3.14.3 (main, Feb 13 2026, 15:31:44) [GCC 15.2.1 20260209] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> import serial
>>> ser = serial.Serial('/dev/ttyUSB0')
>>>
Exception ignored while finalizing file Serial<id=0x7f44c8717dc0, open=True>(name='/dev/ttyUSB0', baudrate=9600, bytesize=8, parity='N', stopbits=1, timeout=None, xonxoff=False, rtscts=False, dsrdtr=False):
Traceback (most recent call last):
  File "/home/bilbo/clones/pyserial/serial/serialposix.py", line 537, in close
TypeError: 'NoneType' object is not callable
```

`weakref.finalize` is not vulnerable to this issue, as finalizers run before modules are torn down.

Note that finalizers are guaranteed to run exactly once, so it's not strictly necessary to replace it with `None` in `close()`, and because the finalizer's lifecycle is tied to `self.fd` we should not have to check if it's `None`. We do both of these anyway for clarity.

`weakref.finalize` was introduced in Python 3.4.