### PR TITLE
Preserve errno on Windows serial open failures

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -61,7 +61,8 @@ class Serial(SerialBase):
             0)
         if self._port_handle == win32.INVALID_HANDLE_VALUE:
             self._port_handle = None    # 'cause __del__ is called anyway
-            raise SerialException("could not open port {!r}: {!r}".format(self.name, ctypes.WinError()))
+            we = ctypes.WinError()
+            raise SerialException(we.errno, "could not open port {!r}: {!r}".format(self.name, we))
 
         try:
             self._overlapped_read = win32.OVERLAPPED()


### PR DESCRIPTION
Serial.open() on Windows raised SerialException from a single formatted string, stringifying the WinError and discarding its structured error code. As a result, SerialException.errno was always None on Windows, while the POSIX path populates it via the OSError constructor. Callers could not branch on the failure cause (port not found vs. access denied vs. busy) without parsing the exception message.

Pass the error code as the first positional argument so the OSError base class sets .errno, mirroring serialposix.py. The message format is unchanged, so this is non-breaking for code that only reads str(e).

Fixes #865