### PR TITLE
Add miniterm options to pulse RTS or DTR after opening

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@
 Unreleased
 ==========
 
+**New Features**
+
+- [#756] miniterm: Add ``--toggle`` and ``--toggle-duration`` to pulse RTS or
+  DTR once after opening the port, useful to reset a device that watches
+  this line.
+
 
 **Python support**
 

--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -216,9 +216,10 @@ Command line options ``python -m serial.tools.miniterm -h``::
       --xonxoff             enable software flow control (default off)
       --rts RTS             set initial RTS line state (possible values: 0, 1)
       --dtr DTR             set initial DTR line state (possible values: 0, 1)
-      --toggle {rts,dtr}    pulse RTS or DTR once after opening the port, useful
-                            to reset a device that watches this line, see
-                            --toggle-duration
+      --toggle {rts,dtr}    pulse RTS or DTR once after opening the port
+                            (low/high/low or high/low/high, whichever the line
+                            is currently not at), useful to reset a device
+                            that watches this line, see --toggle-duration
       --toggle-duration SECONDS
                             duration of the pulse set with --toggle, default: 0.1
       --ask                 ask again for port when open fails

--- a/documentation/tools.rst
+++ b/documentation/tools.rst
@@ -195,7 +195,8 @@ such as ``rfc2217://<host>:<port>`` respectively ``socket://<host>:<port>`` as
 Command line options ``python -m serial.tools.miniterm -h``::
 
     usage: miniterm.py [-h] [--parity {N,E,O,S,M}] [--rtscts] [--xonxoff]
-                       [--rts RTS] [--dtr DTR] [-e] [--encoding CODEC] [-f NAME]
+                       [--rts RTS] [--dtr DTR] [--toggle {rts,dtr}]
+                       [--toggle-duration SECONDS] [-e] [--encoding CODEC] [-f NAME]
                        [--eol {CR,LF,CRLF}] [--raw] [--exit-char NUM]
                        [--menu-char NUM] [-q] [--develop]
                        [port] [baudrate]
@@ -215,6 +216,11 @@ Command line options ``python -m serial.tools.miniterm -h``::
       --xonxoff             enable software flow control (default off)
       --rts RTS             set initial RTS line state (possible values: 0, 1)
       --dtr DTR             set initial DTR line state (possible values: 0, 1)
+      --toggle {rts,dtr}    pulse RTS or DTR once after opening the port, useful
+                            to reset a device that watches this line, see
+                            --toggle-duration
+      --toggle-duration SECONDS
+                            duration of the pulse set with --toggle, default: 0.1
       --ask                 ask again for port when open fails
 
     data handling:

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -13,6 +13,7 @@ import codecs
 import os
 import sys
 import threading
+import time
 
 import serial
 from serial.tools.list_ports import comports
@@ -889,6 +890,22 @@ def main(default_port=None, default_baudrate=9600, default_rts=None, default_dtr
         default=default_dtr)
 
     group.add_argument(
+        '--toggle',
+        choices=['rts', 'dtr'],
+        help='pulse RTS or DTR once after opening the port (low/high/low or '
+             'high/low/high, whichever the line is currently not at), '
+             'useful to reset a device that watches this line, '
+             'see --toggle-duration',
+        default=None)
+
+    group.add_argument(
+        '--toggle-duration',
+        type=float,
+        metavar='SECONDS',
+        help='duration of the pulse set with --toggle, default: %(default)s',
+        default=0.1)
+
+    group.add_argument(
         '--non-exclusive',
         dest='exclusive',
         action='store_false',
@@ -1024,6 +1041,18 @@ def main(default_port=None, default_baudrate=9600, default_rts=None, default_dtr
                 serial_instance.exclusive = args.exclusive
 
             serial_instance.open()
+
+            if args.toggle is not None:
+                if not args.quiet:
+                    sys.stderr.write('--- toggling {} ---\n'.format(args.toggle.upper()))
+                if args.toggle == 'rts':
+                    serial_instance.rts = not serial_instance.rts
+                    time.sleep(args.toggle_duration)
+                    serial_instance.rts = not serial_instance.rts
+                elif args.toggle == 'dtr':
+                    serial_instance.dtr = not serial_instance.dtr
+                    time.sleep(args.toggle_duration)
+                    serial_instance.dtr = not serial_instance.dtr
         except serial.SerialException as e:
             sys.stderr.write('could not open port {!r}: {}\n'.format(args.port, e))
             if args.develop:

--- a/serial/tools/miniterm.py
+++ b/serial/tools/miniterm.py
@@ -988,6 +988,9 @@ def main(default_port=None, default_baudrate=9600, default_rts=None, default_dtr
     if args.menu_char == args.exit_char:
         parser.error('--exit-char can not be the same as --menu-char')
 
+    if args.toggle_duration < 0:
+        parser.error('--toggle-duration can not be negative')
+
     if args.filter:
         if 'help' in args.filter:
             sys.stderr.write('Available filters:\n')
@@ -1044,7 +1047,7 @@ def main(default_port=None, default_baudrate=9600, default_rts=None, default_dtr
 
             if args.toggle is not None:
                 if not args.quiet:
-                    sys.stderr.write('--- toggling {} ---\n'.format(args.toggle.upper()))
+                    sys.stderr.write('--- toggling {}\n'.format(args.toggle.upper()))
                 if args.toggle == 'rts':
                     serial_instance.rts = not serial_instance.rts
                     time.sleep(args.toggle_duration)


### PR DESCRIPTION
## Summary

Some hardware needs a manual pulse on RTS or DTR to trigger a reset, a real pattern from automated test/bootloader benches. `miniterm.py` already has `--rts`/`--dtr` to force a static initial line *state* before opening, but nothing to *pulse* a line after opening.

Adds:
- `--toggle {rts,dtr}` — pulse the chosen line once after the port opens (flip, hold, flip back), preserving the original state.
- `--toggle-duration SECONDS` — configurable pulse width, default `0.1`.

Addresses #756.

A prior attempt at this issue (#845) was opened in Dec 2025 and self-closed by its own author after 5+ weeks with no maintainer engagement. This version differs in a few ways: the pulse duration is configurable rather than a hardcoded `time.sleep(0.1)`, both `--rts`/`--dtr`-style docs and `CHANGES.rst` are updated, and invalid input (bad `--toggle` choice, negative `--toggle-duration`) is rejected via `argparse`/`parser.error()` before any port is opened or line touched, matching the file's existing validation style for `--exit-char`/`--menu-char`.

## Test plan

- Exercised the toggle logic directly against a `loop://` virtual port (no hardware needed): confirmed both RTS and DTR flip, hold for the configured duration, and restore to their original state.
- Verified argparse wiring via `--help` and targeted invalid-input runs: `--toggle bogus` and `--toggle-duration -1` are both rejected with a clear error before a port is opened.
- `--toggle-duration 0` (instantaneous pulse) verified to still work correctly.
- `flake8 serial/tools/miniterm.py`: zero new warnings (3 pre-existing warnings in the file, unrelated to this diff, confirmed identical on `master`).
- `git diff --check`: clean.

## Note

While tracing the toggle placement I found a pre-existing, unrelated issue: if a `SerialException` is raised anywhere after `serial_instance` is assigned (already true today for the existing `--dtr`/`--rts` forcing code, and now also possible during the new toggle), the `--ask` retry loop's `while serial_instance is None:` condition is already false on the next iteration, so it silently stops retrying instead of prompting for a new port. Confirmed this exists identically on current `master`, unrelated to this change. Keeping it out of scope here since it's a separate concern from #756; happy to file it separately if useful.