### PR TITLE
win32: fix opening a `COM0` serial port

### DIFF
--- a/serial/serialwin32.py
+++ b/serial/serialwin32.py
@@ -13,11 +13,29 @@ from __future__ import absolute_import
 
 # pylint: disable=invalid-name,too-few-public-methods
 import ctypes
+import re
 import time
 from serial import win32
 
 import serial
 from serial.serialutil import SerialBase, SerialException, to_bytes, PortNotOpenError, SerialTimeoutException
+
+
+LEGACY_DOS_DEVICE_NAMES = frozenset('COM{}'.format(number) for number in range(1, 10))
+COM_PORT_NAME = re.compile('COM[0-9]+', re.IGNORECASE)
+
+
+def device_path(port):
+    r"""Return the name that Windows resolves to the given serial port.
+
+    Windows resolves only the bare names COM1 through COM9 as MS-DOS device
+    aliases. No other serial port has an alias, so COM0 as well as COM10 and
+    above must be named in the "\\.\COMx" device namespace format; a bare name
+    would be resolved as an ordinary relative file system path instead.
+    """
+    if COM_PORT_NAME.fullmatch(port) and port.upper() not in LEGACY_DOS_DEVICE_NAMES:
+        return '\\\\.\\' + port
+    return port
 
 
 class Serial(SerialBase):
@@ -41,18 +59,8 @@ class Serial(SerialBase):
             raise SerialException("Port must be configured before it can be used.")
         if self.is_open:
             raise SerialException("Port is already open.")
-        # the "\\.\COMx" format is required for devices other than COM1-COM8
-        # not all versions of windows seem to support this properly
-        # so that the first few ports are used with the DOS device name
-        port = self.name
-        try:
-            if port.upper().startswith('COM') and int(port[3:]) > 8:
-                port = '\\\\.\\' + port
-        except ValueError:
-            # for like COMnotanumber
-            pass
         self._port_handle = win32.CreateFile(
-            port,
+            device_path(self.name),
             win32.GENERIC_READ | win32.GENERIC_WRITE,
             0,  # exclusive access
             None,  # no security

--- a/test/test_serialwin32.py
+++ b/test/test_serialwin32.py
@@ -1,0 +1,66 @@
+# This file is part of pySerial - Cross platform serial port support for Python
+#
+# SPDX-License-Identifier:    BSD-3-Clause
+
+"""
+Test the Win32 serial port naming.
+"""
+
+import os
+
+import pytest
+
+if os.name == "nt":
+    from serial import serialwin32, win32
+
+pytestmark = pytest.mark.skipif(os.name != "nt", reason="Windows only")
+
+
+@pytest.mark.parametrize(
+    "port, expected",
+    (
+        ("COM1", "COM1"),
+        ("COM8", "COM8"),
+        ("COM9", "COM9"),
+        ("com3", "com3"),
+        ("COM0", r"\\.\COM0"),
+        ("com0", r"\\.\com0"),
+        ("COM00", r"\\.\COM00"),
+        ("COM01", r"\\.\COM01"),
+        ("COM10", r"\\.\COM10"),
+        ("COM255", r"\\.\COM255"),
+        (r"\\.\COM1", r"\\.\COM1"),
+        (r"\\.\COM0", r"\\.\COM0"),
+        ("COM", "COM"),
+        ("COMnotanumber", "COMnotanumber"),
+        ("/dev/ttyS0", "/dev/ttyS0"),
+    ),
+)
+def test_device_path(port, expected):
+    """Verify that every port without an MS-DOS device alias is prefixed."""
+
+    assert serialwin32.device_path(port) == expected
+
+
+@pytest.mark.parametrize(
+    "port, expected",
+    (
+        pytest.param("COM0", r"\\.\COM0", id="device-namespace"),
+        pytest.param("COM1", "COM1", id="ms-dos-alias"),
+    ),
+)
+def test_open_names_the_device(monkeypatch, port, expected):
+    """Verify that `open()` hands the resolvable name to CreateFile."""
+
+    names = []
+
+    def create_file(name, *args):
+        names.append(name)
+        return win32.INVALID_HANDLE_VALUE
+
+    monkeypatch.setattr(win32, "CreateFile", create_file)
+
+    with pytest.raises(serialwin32.SerialException):
+        serialwin32.Serial(port)
+
+    assert names == [expected]


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> This post was authored by `claude-opus-5` on behalf of @JPHutchins. She asked me to research #870 — which she filed after a field report of a "cannot open COM0" failure on a Windows manufacturing PC — and open a PR resolving it. I picked which of the candidate fixes to implement, extracted the naming rule into a testable function, and wrote the regression tests.

Fixes #870.

## Summary

**On Windows, pySerial lists a `COM0` device and then cannot open it.**

Windows recognizes only the bare names `COM1` through `COM9`; every other serial port must be addressed as `\\.\COMx`. pySerial applied that prefix only when the port number was greater than 8 — and `0` is not greater than `8`, so `COM0` reached `CreateFile` bare, where Windows resolved it as an ordinary **relative file path** instead of a device. The open then failed with `FileNotFoundError(2)`. Opening `r"\\.\COM0"` by hand works on the same machine, which is the proof that the device is real and only the name pySerial built was wrong.

This replaces the numeric comparison with the rule Windows actually follows — prefix every COM port that has no bare name:

```diff
-        if port.upper().startswith('COM') and int(port[3:]) > 8:
-            port = '\\\\.\\' + port
+    if COM_PORT_NAME.fullmatch(port) and port.upper() not in LEGACY_DOS_DEVICE_NAMES:
+        return '\\\\.\\' + port
```

| port name | before | after |
| --- | --- | --- |
| `COM1` … `COM8` | bare | bare — unchanged |
| `COM9` | `\\.\COM9` | bare |
| **`COM0`** | **bare — could not be opened** | **`\\.\COM0`** |
| `COM00`, `COM01` … `COM09` | bare — could not be opened | `\\.\COM0x` |
| `COM10` and above | `\\.\COMx` | unchanged |
| `COMnotanumber`, `\\.\COM3`, `/dev/ttyS0`, … | bare | unchanged |

**`COM1` through `COM9` keep using their bare MS-DOS names, so nothing changes for the ports nearly everyone uses.** The new `test/test_serialwin32.py` pins every row of that table, and two further tests drive the real `Serial.open()` and assert the exact string `CreateFile` receives.

---

<details>
<summary><b>Why <code>COM0</code> fails, and why a machine has one</b></summary>

Microsoft's [Naming Files, Paths, and Namespaces](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file) lists the reserved device names exhaustively — `COM1` through `COM9` are there, `COM0` is not. So `COM0` gets no legacy alias and must be reached through the device namespace, exactly like `COM56` on a port expander. The same page confirms `COM0` *is* a real, reachable device object, and that the `\\.\` prefix works for the reserved names too.

`serial/tools/list_ports_windows.py` reads `PortName` straight out of the device's registry key and reports it verbatim, which is why pySerial will tell you `COM0` exists and then refuse to open it. That asymmetry is what makes this hard to diagnose in the field — the device is visibly right there.

> [!NOTE]
> Windows' own port allocator cannot produce a `COM0`: the arbiter bitmask at `COM Name Arbiter\ComDB` starts at bit 0 = `COM1`, and Device Manager's *COM Port Number* dropdown starts at 1. A `COM0` therefore always comes from something writing `PortName` directly — a vendor INF with a hardcoded `AddReg`, EEPROM-programmed names from FTDI/CP210x tooling, imaging or provisioning scripts, or fallout from the widely circulated "zero out ComDB to reset your COM ports" procedure. None of those are exotic in a manufacturing environment, and the GUI cannot create the state, which is likely why this went unreported for so long.

<details>
<summary>Verified against the kernel path parser</summary>

`ntdll!RtlIsDosDeviceName_U` is the routine Win32 path handling uses to decide whether a name refers to a device. Nonzero means "this is a DOS device name":

| name | `RtlIsDosDeviceName_U` | needs `\\.\` | pySerial before this PR | verdict |
| --- | --- | --- | --- | --- |
| `COM0` | `0` | **yes** | **no** | **broken** |
| `COM1` … `COM8` | `8` | no | no | ok |
| `COM9` | `8` | no | yes | harmless, redundant prefix |
| `COM10`, `COM255` | `0` | yes | yes | ok |
| `COM00`, `COM01` | `0` | **yes** | **no** | **broken** |
| `com0` | `0` | **yes** | **no** | **broken** |

`0` is the only port number the old predicate got wrong for a name Windows actually emits.

</details>

<details>
<summary>Empirical proof that the bare name resolves as a file path</summary>

Place an **ordinary text file** named `COM0` in the working directory, then ask pySerial to open port `COM0`:

```
--- python open() of relative names in cwd ---
  open('COM0','w') -> CREATED A REGULAR FILE          (the name is not a device)
  open('COM1','w') -> OSError 'No such file or directory'
                                                      (hit the COM1 *device*, absent here)

--- pyserial 3.5 ---
  Serial('COM0')      -> SerialException: Cannot configure port, something went wrong.
                         Original message: OSError(22, 'The parameter is incorrect.', None, 87)
  Serial(r'\\.\COM0') -> could not open port: FileNotFoundError(2)
                                                      (no COM0 device on this machine)
```

`Serial('COM0')` obtained a handle **to the text file** and only failed later at `SetCommState`. No device-namespace lookup happened at all.

> [!IMPORTANT]
> A consequence worth knowing regardless of this PR: **the symptom is working-directory dependent.** The usual failure is `FileNotFoundError(2)`, but if anything named `COM0` happens to sit in the process's CWD, the user instead gets `ERROR_INVALID_PARAMETER (87)` / "Cannot configure port" — which looks like a baud rate, flow control, or driver fault and sends the investigation in entirely the wrong direction.

</details>

</details>

<details>
<summary><b>The change, and three things a reviewer should look at</b></summary>

```python
LEGACY_DOS_DEVICE_NAMES = frozenset('COM{}'.format(number) for number in range(1, 10))
COM_PORT_NAME = re.compile('COM[0-9]+', re.IGNORECASE)


def device_path(port):
    r"""Return the name that Windows resolves to the given serial port.

    Windows resolves only the bare names COM1 through COM9 as MS-DOS device
    aliases. No other serial port has an alias, so COM0 as well as COM10 and
    above must be named in the "\\.\COMx" device namespace format; a bare name
    would be resolved as an ordinary relative file system path instead.
    """
    if COM_PORT_NAME.fullmatch(port) and port.upper() not in LEGACY_DOS_DEVICE_NAMES:
        return '\\\\.\\' + port
    return port
```

<details>
<summary>1. The Windows-9x caution in the old comment is honored, not retired</summary>

The replaced comment read:

```python
# the "\\.\COMx" format is required for devices other than COM1-COM8
# not all versions of windows seem to support this properly
# so that the first few ports are used with the DOS device name
```

This change makes **no** assumption about how well a prefixed legacy name is accepted, because `COM1` through `COM9` still use the MS-DOS device name. `COM9` actually moves *toward* that caution: it is a reserved name, so the prefix it used to receive was redundant, and it now takes the same path as `COM1`–`COM8`.

The comment's stated boundary was also off by one — it is `COM1`–`COM9`, not `COM1`–`COM8`, which is exactly where `COM9`'s redundant prefix came from. The substance of the comment now lives in the `device_path()` docstring, corrected.

</details>

<details>
<summary>2. Existing user-side workarounds keep working</summary>

An already-prefixed `\\.\COM0` does not match `COM[0-9]+`, so it is passed through untouched and never doubled. Both organizations described in #870 are prefixing `COM0` themselves today; a fix that broke those workarounds would be worse than the bug.

</details>

<details>
<summary>3. The <code>int()</code> call and its <code>ValueError</code> guard are gone, without changing what they protected</summary>

The old code needed `try: ... except ValueError` purely because `int(port[3:])` raises on names like `COMnotanumber`. Requiring the name to be `COM` followed by decimal digits leaves every non-numeric name untouched, so that guard is no longer needed rather than merely relocated.

This is also why the fix is not simply `int(port[3:]) not in range(1, 10)`, which was the minimal patch proposed in #870: `int("00") == 0` is caught, but `int("01") == 1` is not, so zero-padded names would stay broken. Matching on the literal digits closes the whole class.

`device_path()` is a module-level function rather than inline in `open()` so the naming rule can be tested without a serial port — `open()` is otherwise untestable without hardware.

</details>

</details>

<details>
<summary><b>Tests and verification</b></summary>

`test/test_serialwin32.py` is new and skipped unless `os.name == "nt"`, so it runs in the existing `windows-2025` job rather than being dead weight on other platforms:

- **15 parametrized `device_path()` cases** pinning every row of the summary table, including the lowercase `com0` spelling, the already-prefixed idempotency case, and the non-COM pass-throughs.
- **2 cases driving the real `Serial.open()`** with `win32.CreateFile` monkeypatched, asserting the exact name it receives: `\\.\COM0` for `COM0`, and a bare `COM1` for `COM1`. These guard the wiring, so the fix cannot later be silently disconnected from `open()`.

<details>
<summary>What was run</summary>

The full matrix was run on a fork, because CI on fork PRs to this repo waits for maintainer approval. I also ran a **baseline** with a tree byte-identical to upstream master, so every result below is a comparison rather than an absolute:

| job | this branch | unmodified master |
| --- | --- | --- |
| Windows, Python 3.10 – 3.14 | ✅ | ✅ |
| Linux | ✅ | ✅ |
| macOS | ✅ | ✅ |
| Cygwin | ❌ | ❌ |

- this branch — [intercreate/pyserial run 30479879637](https://github.com/intercreate/pyserial/actions/runs/30479879637)
- baseline — [intercreate/pyserial run 30480209807](https://github.com/intercreate/pyserial/actions/runs/30480209807)

Locally, the suite is 109 passed / 23 skipped on Linux, and all 17 new tests pass rather than skip when run against a stubbed `serial.win32`.

> [!NOTE]
> **The Cygwin job is already failing on master, unrelated to this PR — you may not have noticed yet.**
>
> It fails identically on the byte-identical baseline. Every failure line is `could not find python interpreter matching any of the specs py3.1x`: that job installs only `python312`, but `pip install tox` is unpinned and now resolves tox 4.58.0, which errors on missing interpreters instead of skipping them. The last green Cygwin run on master was 2026-02-27, so this is environment drift since then.
>
> The one environment that does still run there is the most direct evidence that this PR is inert off Windows: `109 passed, 6 skipped` on master versus `109 passed, 23 skipped` on this branch — the 17 extra skips are exactly this PR's Windows-only tests declining to run.

</details>

> [!IMPORTANT]
> **What I could not test.** I have no `COM0` device and no Windows machine of my own, so the behavior of the fix against real `COM0` hardware is argued from Microsoft's documentation and the analysis in #870, not observed. What CI does prove is that the name pySerial now constructs is `\\.\COM0`, and that nothing else changed. Per #870, the equivalent `\\.\COM0` normalization has been in continuous production use at one of the two organizations since September 2024 across many thousands of units, deployed on the strength of the documentation alone for exactly this reason — the state cannot be reproduced on a developer machine.

</details>

<details>
<summary><b>Prior art: other ecosystems have hit this same ambiguity</b></summary>

Linked in solidarity, and as independent corroboration that the premise here is established rather than a novel claim.

<details>
<summary>Go reached the same conclusion about <code>COM0</code>, independently</summary>

[golang/go#67245](https://github.com/golang/go/issues/67245) — *"path/filepath: COM0 and LPT0 are now reserved on Windows"* — is the same question asked about Go's `path/filepath`, and answered the same way:

> `COM[1-9]` and `LPT[1-9]` are reserved names on Windows, and should only be used to refer to existing serial or parallel ports.
> — `alexbrainman`

> I think for `path/filepath`, we should stick with treating LPT0 and COM0 as non-reserved. Whether they're officially "reserved" or not, they're empirically available for use and I can't imagine Microsoft with their admirable commitment to backwards compatibility changing that at this point. All this behavior has been stable for decades.
> — `neild`

"Empirically available for use" as a *file name* is precisely why a bare `COM0` handed to `CreateFile` opens a file instead of a port.

</details>

<details>
<summary>Microsoft's own documentation was wrong about this for about two and a half years</summary>

This is worth knowing, because it is probably why the bug survived so long — anyone who checked the docs during that window got the wrong answer.

- [MicrosoftDocs/win32@2274ec1c](https://github.com/MicrosoftDocs/win32/commit/2274ec1c189564d9fbb6f4a6d885ea6cc95f059a) (2022-11-23) added `COM0` and `LPT0` to the reserved-name list, by a non-Microsoft contributor, with the message *"COM0 and LPT0 are also not allowed."*
- [MicrosoftDocs/win32#2008](https://github.com/MicrosoftDocs/win32/pull/2008) → [4fde3c1d](https://github.com/MicrosoftDocs/win32/commit/4fde3c1de423dece99b0e077bd651b9aa327c0bf) (2025-04-11) reverted it: *"Fix COM0 and LPT0 incorrectly listed as reserved"* — prompted by the Go discussion above.

The page as it stands today is the corrected version, and is what #870 quotes: `COM0` is absent from the reserved-name list, while the same page still documents `COM0` as a real device object (*"COM0 and COM1 under the 'Global??' subdirectory are simply symlinks to Serial0 and Serial1"*) and states that the `\\.\` prefix *"will also work with these device names."*

</details>

<details>
<summary>Downstream projects already prefix every COM name themselves</summary>

Effectively option 3 from #870 — always prefix — adopted in the field to route around this heuristic:

- `TexasInstruments/simplelink-lowpower-f2-sdk` and `-f3-sdk`, [`serial_rx.py`](https://github.com/TexasInstruments/simplelink-lowpower-f2-sdk/blob/main/tools/log/tiutils/streams/uart/tilogger_uart_transport/serial_rx.py) — prefixes any port that is not already `\`-rooted and not a `/dev` path, immediately before `serial.Serial()`, under the comment *"Check port path for corner case"*
- `onlogic/Pykarbon`, [`hardware.py`](https://github.com/onlogic/Pykarbon/blob/master/pykarbon/hardware.py) — *"Fix for windows COM ports above 10"*
- `CartesianCo/argentum-control`, [`avrdude.py`](https://github.com/CartesianCo/argentum-control/blob/develop/src/avrdude.py) — unconditional prefix on Windows

Because the prefix is idempotent under this change, none of these break.

</details>

<details>
<summary>And the heuristic gets re-derived, with the same gap</summary>

`Osiakosia/Emterprise-logger-adminite-`, [`serial_io.py`](https://github.com/Osiakosia/Emterprise-logger-adminite-/blob/main/app/core/serial_io.py), independently reimplements this logic ahead of its own `serial.Serial()` call — `int(port[3:])`, `ValueError` guard and all — with the boundary at `n >= 10`, and so reproduces the same `COM0` gap:

```python
# Windows: COM10+ may need \\.\COM10
if isinstance(port, str) and port.upper().startswith("COM"):
    try:
        n = int(port[3:])
        if n >= 10 and not port.startswith("\\\\.\\"):
            port = "\\\\.\\" + port
    except ValueError:
        pass
```

Not a criticism of that project — the point is that "prefix above some threshold" is the intuitive reading, and every threshold anyone picks excludes `0`. That is an argument for stating the rule as the set of names Windows actually reserves, which is what this PR does.

</details>

</details>

<details>
<summary><b>Housekeeping</b></summary>

- **No conflict with #866**, which touches the `INVALID_HANDLE_VALUE` branch a few lines below this change.
- **No `CHANGES.rst` entry**, since recent merged bugfixes have not added them and the changelog looks maintainer-curated. Happy to add one on request.
- Happy to reshape any of this — including reverting the `COM9` delta or keeping the fix inline in `open()` — if you would prefer a smaller diff.

</details>
