### PR TITLE
Keep list_ports importable on Android

### DIFF
--- a/serial/tools/list_ports_posix.py
+++ b/serial/tools/list_ports_posix.py
@@ -104,6 +104,20 @@ elif plat[:5] == 'haiku':    # Haiku
             devices.update(list_ports_common.list_links(devices))
         return [list_ports_common.ListPortInfo(d) for d in devices]
 
+elif plat[:7] == 'android':   # Android / Termux
+    def comports(include_links=False):
+        """scan for serial ports exposed as device nodes.
+
+        Most unrooted Android/Termux environments do not expose USB serial
+        adapters as /dev/ttyACM* or /dev/ttyUSB*. Returning an empty list keeps
+        serial.tools.list_ports importable; applications that know a concrete
+        device path can still try to open it explicitly.
+        """
+        devices = set(glob.glob('/dev/ttyACM*') + glob.glob('/dev/ttyUSB*'))
+        if include_links:
+            devices.update(list_ports_common.list_links(devices))
+        return [list_ports_common.ListPortInfo(d) for d in devices]
+
 else:
     # platform detection has failed...
     import serial


### PR DESCRIPTION
## Summary
- add an Android/Termux branch to `serial.tools.list_ports_posix`
- scan for `/dev/ttyACM*` and `/dev/ttyUSB*` when such nodes are available
- return an empty list instead of raising ImportError on typical unrooted Android systems

## Context
On Termux, `sys.platform` is `android`. Importing `serial.tools.list_ports` currently raises from `list_ports_posix.py`, which can break applications before they have a chance to open an explicit port or custom URL.

This does not implement Android USB host support; Android still often exposes USB devices only through the Android USB APIs/Termux USB file descriptors. It simply makes `list_ports` behave like a valid-but-empty enumerator unless tty device nodes exist.

## Testing
- `python -m py_compile serial/tools/list_ports_posix.py`
- Hardware context: reproduced on Android/Termux with a USB CDC ACM ESP32-S2/S3-class device where no `/dev/ttyACM*` or `/dev/ttyUSB*` nodes were exposed.